### PR TITLE
v0.2.1

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -98,3 +98,4 @@ jobs:
           RUST_LOG: "debug"
           RUST_BACKTRACE: "1"
           SKIP_CLIPPY: "1"
+          CLEAN_BEFORE_EACH: "1"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change log
 
+## v0.2.1
+
+- `qiniu_upload_manager::MultiPartsV1Uploader` 总是使用 4 MB 分片大小，无论 `qiniu_upload_manager::DataPartitionProvider` 返回多大的分片大小。
+- `qiniu_upload_manager::SerialMultiPartsUploaderScheduler` 和 `qiniu_upload_manager::ConcurrentMultiPartsUploaderScheduler` 对空间所在区域上传对象失败后，会使用多活区域继续重试，直到其中有一个能成功为止。
+
 ## v0.2.0
 
 - 大部分 Trait 现在都实现了 Clone，减少了泛型参数以方便被作为 Trait Object 使用

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,9 @@ doc_test:
 test:
 	set -e; \
 	for dir in $(SUBDIRS); do \
+		if [ -n "${CLEAN_BEFORE_EACH}" ]; then \
+			$(MAKE) clean; \
+		fi; \
 		$(MAKE) -C $$dir test; \
 	done
 clean:

--- a/api-generator/Cargo.toml
+++ b/api-generator/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qiniu-api-generator"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Rong Zhou <zhourong@qiniu.com>", "Shanghai Qiniu Information Technologies Co., Ltd."]
 edition = "2021"
 rust-version = "1.60.0"
@@ -29,8 +29,8 @@ walkdir = "2.3.2"
 
 [dev-dependencies]
 serde_json = "1.0.68"
-qiniu-http = { version = "0.2.0", path = "../http" }
-qiniu-http-client = { version = "0.2.0", path = "../http-client" }
-qiniu-upload-token = { version = "0.2.0", path = "../upload-token" }
-qiniu-utils = { version = "0.2.0", path = "../utils" }
+qiniu-http = { version = "0.2.1", path = "../http" }
+qiniu-http-client = { version = "0.2.1", path = "../http-client" }
+qiniu-upload-token = { version = "0.2.1", path = "../upload-token" }
+qiniu-utils = { version = "0.2.1", path = "../utils" }
 indexmap = "1.7.0"

--- a/apis/Cargo.toml
+++ b/apis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qiniu-apis"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Rong Zhou <zhourong@qiniu.com>", "Shanghai Qiniu Information Technologies Co., Ltd."]
 edition = "2021"
 rust-version = "1.60.0"
@@ -22,8 +22,8 @@ indexmap = "1.7.0"
 futures = { version = "0.3.5", optional = true }
 async-std = { version = "1.9.0", optional = true }
 
-qiniu-http-client = { version = "0.2.0", path = "../http-client", default-features = false }
-qiniu-utils = { version = "0.2.0", path = "../utils" }
+qiniu-http-client = { version = "0.2.1", path = "../http-client", default-features = false }
+qiniu-utils = { version = "0.2.1", path = "../utils" }
 
 [features]
 default = ["ureq"]

--- a/apis/README.md
+++ b/apis/README.md
@@ -24,21 +24,21 @@
 
 ```toml
 [dependencies]
-qiniu-apis = { version = "0.2.0", features = ["ureq"] }
+qiniu-apis = { version = "0.2.1", features = ["ureq"] }
 ```
 
 ### 启用 Isahc 异步接口
 
 ```toml
 [dependencies]
-qiniu-apis = { version = "0.2.0", features = ["async", "isahc"] }
+qiniu-apis = { version = "0.2.1", features = ["async", "isahc"] }
 ```
 
 ### 启用 Reqwest 异步接口
 
 ```toml
 [dependencies]
-qiniu-apis = { version = "0.2.0", features = ["async", "reqwest"] }
+qiniu-apis = { version = "0.2.1", features = ["async", "reqwest"] }
 ```
 
 ### 其他功能

--- a/credential/Cargo.toml
+++ b/credential/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qiniu-credential"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Rong Zhou <zhourong@qiniu.com>", "Shanghai Qiniu Information Technologies Co., Ltd."]
 edition = "2021"
 rust-version = "1.60.0"
@@ -24,7 +24,7 @@ assert-impl = "0.1.3"
 auto_impl = "1.0.0"
 futures-lite = { version = "1.12.0", optional = true }
 
-qiniu-utils = { version = "0.2.0", path = "../utils" }
+qiniu-utils = { version = "0.2.1", path = "../utils" }
 
 [dev-dependencies]
 anyhow = "1.0.41"

--- a/credential/README.md
+++ b/credential/README.md
@@ -20,14 +20,14 @@
 
 ```toml
 [dependencies]
-qiniu-credential = "0.2.0"
+qiniu-credential = "0.2.1"
 ```
 
 ### 启用异步接口
 
 ```toml
 [dependencies]
-qiniu-credential = { version = "0.2.0", features = ["async"] }
+qiniu-credential = { version = "0.2.1", features = ["async"] }
 ```
 
 ## 代码示例

--- a/download-manager/Cargo.toml
+++ b/download-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qiniu-download-manager"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Rong Zhou <zhourong@qiniu.com>", "Shanghai Qiniu Information Technologies Co., Ltd."]
 edition = "2021"
 rust-version = "1.60.0"
@@ -26,7 +26,7 @@ futures = { version = "0.3.5", optional = true }
 async-std = { version = "1.9.0", optional = true }
 smart-default = { version = "0.6.0", optional = true }
 
-qiniu-apis = { version = "0.2.0", path = "../apis", default-features = false }
+qiniu-apis = { version = "0.2.1", path = "../apis", default-features = false }
 
 [dev-dependencies]
 rand = "0.8.3"

--- a/download-manager/README.md
+++ b/download-manager/README.md
@@ -16,21 +16,21 @@
 
 ```toml
 [dependencies]
-qiniu-download-manager = { version = "0.2.0", features = ["ureq"] }
+qiniu-download-manager = { version = "0.2.1", features = ["ureq"] }
 ```
 
 ### 启用 Isahc 异步接口
 
 ```toml
 [dependencies]
-qiniu-download-manager = { version = "0.2.0", features = ["async", "isahc"] }
+qiniu-download-manager = { version = "0.2.1", features = ["async", "isahc"] }
 ```
 
 ### 启用 Reqwest 异步接口
 
 ```toml
 [dependencies]
-qiniu-download-manager = { version = "0.2.0", features = ["async", "reqwest"] }
+qiniu-download-manager = { version = "0.2.1", features = ["async", "reqwest"] }
 ```
 
 ### 其他功能

--- a/etag/Cargo.toml
+++ b/etag/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qiniu-etag"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Rong Zhou <zhourong@qiniu.com>", "Shanghai Qiniu Information Technologies Co., Ltd."]
 edition = "2021"
 rust-version = "1.60.0"
@@ -19,7 +19,7 @@ digest = "0.9.0"
 assert-impl = "0.1.3"
 futures-lite = { version = "1.12.0", optional = true }
 
-qiniu-utils = { version = "0.2.0", path = "../utils" }
+qiniu-utils = { version = "0.2.1", path = "../utils" }
 
 [dev-dependencies]
 async-std = { version = "1.9.0", features = ["attributes"] }

--- a/etag/README.md
+++ b/etag/README.md
@@ -18,14 +18,14 @@
 
 ```toml
 [dependencies]
-qiniu-etag = "0.2.0"
+qiniu-etag = "0.2.1"
 ```
 
 ### 启用异步接口
 
 ```toml
 [dependencies]
-qiniu-etag = { version = "0.2.0", features = ["async"] }
+qiniu-etag = { version = "0.2.1", features = ["async"] }
 ```
 
 ## 代码示例

--- a/http-client/Cargo.toml
+++ b/http-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qiniu-http-client"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Rong Zhou <zhourong@qiniu.com>", "Shanghai Qiniu Information Technologies Co., Ltd."]
 edition = "2021"
 rust-version = "1.60.0"
@@ -56,13 +56,13 @@ trust-dns-resolver = { version = "0.21.2", optional = true }
 async-std-resolver = { version = "0.21.2", optional = true }
 async-once-cell = { version = "0.3.0", optional = true }
 
-qiniu-http = { version = "0.2.0", path = "../http" }
-qiniu-credential = { version = "0.2.0", path = "../credential" }
-qiniu-upload-token = { version = "0.2.0", path = "../upload-token" }
-qiniu-reqwest = { version = "0.2.0", path = "../http-reqwest", optional = true }
-qiniu-isahc = { version = "0.2.0", path = "../http-isahc", optional = true }
-qiniu-ureq = { version = "0.2.0", path = "../http-ureq", optional = true }
-qiniu-utils = { version = "0.2.0", path = "../utils" }
+qiniu-http = { version = "0.2.1", path = "../http" }
+qiniu-credential = { version = "0.2.1", path = "../credential" }
+qiniu-upload-token = { version = "0.2.1", path = "../upload-token" }
+qiniu-reqwest = { version = "0.2.1", path = "../http-reqwest", optional = true }
+qiniu-isahc = { version = "0.2.1", path = "../http-isahc", optional = true }
+qiniu-ureq = { version = "0.2.1", path = "../http-ureq", optional = true }
+qiniu-utils = { version = "0.2.1", path = "../utils" }
 
 [dev-dependencies]
 async-std = { version = "1.9.0", features = ["attributes"] }

--- a/http-client/README.md
+++ b/http-client/README.md
@@ -105,21 +105,21 @@
 
 ```toml
 [dependencies]
-qiniu-http-client = { version = "0.2.0", features = ["ureq"] }
+qiniu-http-client = { version = "0.2.1", features = ["ureq"] }
 ```
 
 ### 启用 Isahc 异步接口
 
 ```toml
 [dependencies]
-qiniu-http-client = { version = "0.2.0", features = ["async", "isahc"] }
+qiniu-http-client = { version = "0.2.1", features = ["async", "isahc"] }
 ```
 
 ### 启用 Reqwest 异步接口
 
 ```toml
 [dependencies]
-qiniu-http-client = { version = "0.2.0", features = ["async", "reqwest"] }
+qiniu-http-client = { version = "0.2.1", features = ["async", "reqwest"] }
 ```
 
 ### 其他功能

--- a/http-client/src/client/call/send_http_request.rs
+++ b/http-client/src/client/call/send_http_request.rs
@@ -86,7 +86,7 @@ fn need_retry_after_backoff(err: &TryError) -> bool {
 }
 
 fn handle_response_error(
-    response_error: ResponseError,
+    mut response_error: ResponseError,
     http_parts: &mut HttpRequestParts,
     parts: &InnerRequestParts<'_>,
     retried: &mut RetriedStatsInfo,
@@ -98,6 +98,7 @@ fn handle_response_error(
             .build(),
     );
     retried.increase_current_endpoint();
+    response_error = response_error.set_retry_decision(retry_result.decision());
     TryError::new(response_error, retry_result)
 }
 

--- a/http-client/src/client/chooser/shuffled.rs
+++ b/http-client/src/client/chooser/shuffled.rs
@@ -101,7 +101,7 @@ mod tests {
         );
         assert_eq!(
             make_set(ip_chooser.choose(IPS_WITHOUT_PORT, Default::default())),
-            make_set(&[IpAddrWithPort::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 3)), None)]),
+            make_set([IpAddrWithPort::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 3)), None)]),
         );
 
         ip_chooser.feedback(
@@ -126,7 +126,7 @@ mod tests {
         );
         assert_eq!(
             make_set(ip_chooser.choose(IPS_WITHOUT_PORT, Default::default())),
-            make_set(&[
+            make_set([
                 IpAddrWithPort::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 1)), None),
                 IpAddrWithPort::new(IpAddr::V4(Ipv4Addr::new(192, 168, 1, 2)), None),
             ])

--- a/http-client/src/client/chooser/subnet.rs
+++ b/http-client/src/client/chooser/subnet.rs
@@ -114,7 +114,7 @@ impl Chooser for SubnetChooser {
                 }
             }
         }
-        let chosen_ips = choose_group(subnets_map.into_iter().map(|(_, ips)| ips)).unwrap_or_default();
+        let chosen_ips = choose_group(subnets_map.into_values()).unwrap_or_default();
         do_some_work_async(&self.inner, need_to_shrink);
         return chosen_ips.into();
 

--- a/http-client/src/client/request/multipart.rs
+++ b/http-client/src/client/request/multipart.rs
@@ -282,8 +282,8 @@ mod sync_part {
         /// 设置阻塞 Multipart 的请求体为文件
         pub fn file_path<S: AsRef<OsStr> + ?Sized>(path: &S) -> IoResult<Self> {
             let path = Path::new(path);
-            let file = File::open(&path)?;
-            let mut metadata = PartMetadata::default().mime(mime_guess::from_path(&path).first_or_octet_stream());
+            let file = File::open(path)?;
+            let mut metadata = PartMetadata::default().mime(mime_guess::from_path(path).first_or_octet_stream());
             if let Some(file_name) = path.file_name() {
                 let file_name = match file_name.to_string_lossy() {
                     Cow::Borrowed(str) => FileName::from(str),
@@ -420,7 +420,7 @@ mod async_part {
         pub async fn file_path<S: AsRef<OsStr> + ?Sized>(path: &S) -> IoResult<AsyncPart<'a>> {
             let path = Path::new(path);
             let file = File::open(&path).await?;
-            let mut metadata = PartMetadata::default().mime(mime_guess::from_path(&path).first_or_octet_stream());
+            let mut metadata = PartMetadata::default().mime(mime_guess::from_path(path).first_or_octet_stream());
             if let Some(file_name) = path.file_name() {
                 let file_name = match file_name.to_string_lossy() {
                     Cow::Borrowed(str) => FileName::from(str),

--- a/http-client/src/client/response/error.rs
+++ b/http-client/src/client/response/error.rs
@@ -1,5 +1,5 @@
 use super::{
-    super::super::{EndpointParseError, RetriedStatsInfo},
+    super::super::{EndpointParseError, RetriedStatsInfo, RetryDecision},
     X_LOG_HEADER_NAME, X_REQ_ID_HEADER_NAME,
 };
 use anyhow::Error as AnyError;
@@ -62,6 +62,7 @@ pub struct Error {
     x_headers: XHeaders,
     response_body_sample: Vec<u8>,
     retried: Option<RetriedStatsInfo>,
+    retry_decision: Option<RetryDecision>,
     extensions: Extensions,
 }
 
@@ -80,6 +81,7 @@ impl Error {
             x_headers: Default::default(),
             response_body_sample: Default::default(),
             retried: Default::default(),
+            retry_decision: Default::default(),
             extensions: Default::default(),
         }
     }
@@ -96,6 +98,7 @@ impl Error {
             x_headers: Default::default(),
             response_body_sample: Default::default(),
             retried: Default::default(),
+            retry_decision: Default::default(),
             extensions: Default::default(),
         }
     }
@@ -105,6 +108,14 @@ impl Error {
     #[must_use]
     pub fn retried(mut self, retried: &RetriedStatsInfo) -> Self {
         self.retried = Some(retried.to_owned());
+        self
+    }
+
+    /// 设置重试决定
+    #[inline]
+    #[must_use]
+    pub fn set_retry_decision(mut self, retry_decision: RetryDecision) -> Self {
+        self.retry_decision = Some(retry_decision);
         self
     }
 
@@ -150,6 +161,12 @@ impl Error {
     #[inline]
     pub fn kind(&self) -> ErrorKind {
         self.kind
+    }
+
+    /// 获取重试决定
+    #[inline]
+    pub fn retry_decision(&self) -> Option<RetryDecision> {
+        self.retry_decision
     }
 
     /// 获取响应体样本
@@ -214,6 +231,7 @@ impl Error {
             error: err.into_inner(),
             response_body_sample: Default::default(),
             retried: Default::default(),
+            retry_decision: Default::default(),
             extensions: Default::default(),
         }
     }

--- a/http-client/src/client/retrier/error.rs
+++ b/http-client/src/client/retrier/error.rs
@@ -37,7 +37,7 @@ impl RequestRetrier for ErrorRetrier {
             ResponseErrorKind::UnexpectedStatusCode(_) => RetryDecision::DontRetry,
             ResponseErrorKind::StatusCodeError(status_code) => match status_code.as_u16() {
                 0..=399 => panic!("Should not arrive here"),
-                400..=501 | 579 | 599 | 608 | 612 | 614 | 616 | 618 | 630 | 631 | 632 | 640 | 701 => {
+                400..=499 | 501 | 579 | 608 | 612 | 614 | 616 | 618 | 630 | 631 | 632 | 640 | 701 => {
                     RetryDecision::DontRetry
                 }
                 509 | 573 => RetryDecision::Throttled,

--- a/http-isahc/Cargo.toml
+++ b/http-isahc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qiniu-isahc"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Rong Zhou <zhourong@qiniu.com>", "Shanghai Qiniu Information Technologies Co., Ltd."]
 edition = "2021"
 rust-version = "1.60.0"
@@ -16,7 +16,7 @@ keywords = ["qiniu", "storage"]
 [dependencies]
 anyhow = "1.0.41"
 isahc = { version = "1.4.0" }
-qiniu-http = { version = "0.2.0", path = "../http" }
+qiniu-http = { version = "0.2.1", path = "../http" }
 futures = { version = "0.3.16", optional = true }
 
 [features]

--- a/http-isahc/README.md
+++ b/http-isahc/README.md
@@ -18,14 +18,14 @@
 
 ```toml
 [dependencies]
-qiniu-isahc = "0.2.0"
+qiniu-isahc = "0.2.1"
 ```
 
 ### 启用异步接口
 
 ```toml
 [dependencies]
-qiniu-isahc = { version = "0.2.0", features = ["async"] }
+qiniu-isahc = { version = "0.2.1", features = ["async"] }
 ```
 
 ## 最低支持的 Rust 版本（MSRV）

--- a/http-reqwest/Cargo.toml
+++ b/http-reqwest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qiniu-reqwest"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Rong Zhou <zhourong@qiniu.com>", "Shanghai Qiniu Information Technologies Co., Ltd."]
 edition = "2021"
 rust-version = "1.60.0"
@@ -16,7 +16,7 @@ keywords = ["qiniu", "storage"]
 [dependencies]
 anyhow = "1.0.41"
 reqwest = { version = "0.11.4", features = ["blocking", "stream"] }
-qiniu-http = { version = "0.2.0", path = "../http" }
+qiniu-http = { version = "0.2.1", path = "../http" }
 bytes = { version = "1.0.1", optional = true }
 futures = { version = "0.3.16", optional = true }
 

--- a/http-reqwest/README.md
+++ b/http-reqwest/README.md
@@ -18,14 +18,14 @@
 
 ```toml
 [dependencies]
-qiniu-reqwest = "0.2.0"
+qiniu-reqwest = "0.2.1"
 ```
 
 ### 启用异步接口
 
 ```toml
 [dependencies]
-qiniu-reqwest = { version = "0.2.0", features = ["async"] }
+qiniu-reqwest = { version = "0.2.1", features = ["async"] }
 ```
 
 ## 最低支持的 Rust 版本（MSRV）

--- a/http-ureq/Cargo.toml
+++ b/http-ureq/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qiniu-ureq"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Rong Zhou <zhourong@qiniu.com>", "Shanghai Qiniu Information Technologies Co., Ltd."]
 edition = "2021"
 rust-version = "1.60.0"
@@ -17,7 +17,7 @@ keywords = ["qiniu", "storage"]
 anyhow = "1.0.41"
 ureq = "2.5.0"
 
-qiniu-http = { version = "0.2.0", path = "../http" }
+qiniu-http = { version = "0.2.1", path = "../http" }
 
 [features]
 async = ["qiniu-http/async"]

--- a/http-ureq/README.md
+++ b/http-ureq/README.md
@@ -14,7 +14,7 @@
 
 ```toml
 [dependencies]
-qiniu-ureq = "0.2.0"
+qiniu-ureq = "0.2.1"
 ```
 
 ## 最低支持的 Rust 版本（MSRV）

--- a/http/Cargo.toml
+++ b/http/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qiniu-http"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Rong Zhou <zhourong@qiniu.com>", "Shanghai Qiniu Information Technologies Co., Ltd."]
 edition = "2021"
 rust-version = "1.60.0"
@@ -23,7 +23,7 @@ serde = "1.0.130"
 auto_impl = "1.0.0"
 futures-lite = { version = "1.11.2", optional = true }
 
-qiniu-utils = { version = "0.2.0", path = "../utils" }
+qiniu-utils = { version = "0.2.1", path = "../utils" }
 
 [build-dependencies]
 rustc_version = "0.4.0"

--- a/http/README.md
+++ b/http/README.md
@@ -19,14 +19,14 @@
 
 ```toml
 [dependencies]
-qiniu-http = "0.2.0"
+qiniu-http = "0.2.1"
 ```
 
 ### 启用异步接口
 
 ```toml
 [dependencies]
-qiniu-http = { version = "0.2.0", features = ["async"] }
+qiniu-http = { version = "0.2.1", features = ["async"] }
 ```
 
 ## 最低支持的 Rust 版本（MSRV）

--- a/http/src/lib.rs
+++ b/http/src/lib.rs
@@ -125,6 +125,7 @@ static LIBRARY_USER_AGENT: OnceCell<UserAgent> = OnceCell::new();
 /// 该方法只能调用一次，一旦调用，全局生效
 ///
 /// 每个请求的 UserAgent 由七牛 SDK 固定 UserAgent + 库 UserAgent + 请求的追加 UserAgent 三部分组成
+#[allow(clippy::result_large_err)]
 pub fn set_library_user_agent(user_agent: UserAgent) -> Result<(), UserAgent> {
     LIBRARY_USER_AGENT.set(user_agent)
 }

--- a/objects-manager/Cargo.toml
+++ b/objects-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qiniu-objects-manager"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Rong Zhou <zhourong@qiniu.com>", "Shanghai Qiniu Information Technologies Co., Ltd."]
 edition = "2021"
 rust-version = "1.60.0"
@@ -28,8 +28,8 @@ async-once-cell = { version = "0.3.0", optional = true }
 dyn-clonable = "0.9.0"
 auto_impl = "1.0.0"
 
-qiniu-apis = { version = "0.2.0", path = "../apis", default-features = false }
-qiniu-utils = { version = "0.2.0", path = "../utils" }
+qiniu-apis = { version = "0.2.1", path = "../apis", default-features = false }
+qiniu-utils = { version = "0.2.1", path = "../utils" }
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/objects-manager/README.md
+++ b/objects-manager/README.md
@@ -17,21 +17,21 @@
 
 ```toml
 [dependencies]
-qiniu-objects-manager = { version = "0.2.0", features = ["ureq"] }
+qiniu-objects-manager = { version = "0.2.1", features = ["ureq"] }
 ```
 
 ### 启用 Isahc 异步接口
 
 ```toml
 [dependencies]
-qiniu-objects-manager = { version = "0.2.0", features = ["async", "isahc"] }
+qiniu-objects-manager = { version = "0.2.1", features = ["async", "isahc"] }
 ```
 
 ### 启用 Reqwest 异步接口
 
 ```toml
 [dependencies]
-qiniu-objects-manager = { version = "0.2.0", features = ["async", "reqwest"] }
+qiniu-objects-manager = { version = "0.2.1", features = ["async", "reqwest"] }
 ```
 
 ### 其他功能

--- a/objects-manager/src/list.rs
+++ b/objects-manager/src/list.rs
@@ -110,7 +110,7 @@ impl<'a> ListParams<'a> {
             query_params = query_params.set_limit_as_usize(limit);
         }
         if let Some(prefix) = self.prefix.as_ref() {
-            query_params = query_params.set_prefix_as_str(prefix.to_owned());
+            query_params = query_params.set_prefix_as_str(prefix.clone());
         }
         if self.need_parts {
             query_params = query_params.set_need_parts_as_bool(true);

--- a/objects-manager/src/operation.rs
+++ b/objects-manager/src/operation.rs
@@ -601,7 +601,7 @@ impl ModifyObjectStatus<'_> {
     fn to_path_params(&self) -> qiniu_apis::storage::modify_object_status::PathParams {
         qiniu_apis::storage::modify_object_status::PathParams::default()
             .set_entry_as_str(self.entry.to_string())
-            .set_status_as_usize(if self.disabled { 1 } else { 0 })
+            .set_status_as_usize(usize::from(self.disabled))
     }
 }
 

--- a/sdk-examples/Cargo.toml
+++ b/sdk-examples/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qiniu-sdk-examples"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Rong Zhou <zhourong@qiniu.com>", "Shanghai Qiniu Information Technologies Co., Ltd."]
 edition = "2021"
 rust-version = "1.60.0"
@@ -15,7 +15,7 @@ anyhow = "1.0.41"
 async-std = { version = "1.6.3", features = ["attributes"] }
 env_logger = "0.9.0"
 log = "0.4.14"
-qiniu-sdk = { version = "0.2.0", path = "../sdk", features = ["apis", "upload", "objects", "async", "isahc", "trust_dns"] }
+qiniu-sdk = { version = "0.2.1", path = "../sdk", features = ["apis", "upload", "objects", "async", "isahc", "trust_dns"] }
 structopt = "0.3.23"
 
 [dependencies]

--- a/sdk/Cargo.toml
+++ b/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qiniu-sdk"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Rong Zhou <zhourong@qiniu.com>", "Shanghai Qiniu Information Technologies Co., Ltd."]
 edition = "2021"
 rust-version = "1.60.0"
@@ -14,19 +14,19 @@ keywords = ["qiniu", "storage"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-qiniu-utils = { version = "0.2.0", path = "../utils", optional = true }
-qiniu-etag = { version = "0.2.0", path = "../etag", optional = true }
-qiniu-credential = { version = "0.2.0", path = "../credential", optional = true }
-qiniu-upload-token = { version = "0.2.0", path = "../upload-token", optional = true }
-qiniu-http = { version = "0.2.0", path = "../http", optional = true }
-qiniu-ureq = { version = "0.2.0", path = "../http-ureq", optional = true }
-qiniu-isahc = { version = "0.2.0", path = "../http-isahc", optional = true }
-qiniu-reqwest = { version = "0.2.0", path = "../http-reqwest", optional = true }
-qiniu-http-client = { version = "0.2.0", path = "../http-client", optional = true, default-features = false }
-qiniu-apis = { version = "0.2.0", path = "../apis", optional = true, default-features = false }
-qiniu-objects-manager = { version = "0.2.0", path = "../objects-manager", optional = true, default-features = false }
-qiniu-upload-manager = { version = "0.2.0", path = "../upload-manager", optional = true, default-features = false }
-qiniu-download-manager = { version = "0.2.0", path = "../download-manager", optional = true, default-features = false }
+qiniu-utils = { version = "0.2.1", path = "../utils", optional = true }
+qiniu-etag = { version = "0.2.1", path = "../etag", optional = true }
+qiniu-credential = { version = "0.2.1", path = "../credential", optional = true }
+qiniu-upload-token = { version = "0.2.1", path = "../upload-token", optional = true }
+qiniu-http = { version = "0.2.1", path = "../http", optional = true }
+qiniu-ureq = { version = "0.2.1", path = "../http-ureq", optional = true }
+qiniu-isahc = { version = "0.2.1", path = "../http-isahc", optional = true }
+qiniu-reqwest = { version = "0.2.1", path = "../http-reqwest", optional = true }
+qiniu-http-client = { version = "0.2.1", path = "../http-client", optional = true, default-features = false }
+qiniu-apis = { version = "0.2.1", path = "../apis", optional = true, default-features = false }
+qiniu-objects-manager = { version = "0.2.1", path = "../objects-manager", optional = true, default-features = false }
+qiniu-upload-manager = { version = "0.2.1", path = "../upload-manager", optional = true, default-features = false }
+qiniu-download-manager = { version = "0.2.1", path = "../download-manager", optional = true, default-features = false }
 
 [features]
 default = ["ureq"]

--- a/upload-manager/Cargo.toml
+++ b/upload-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qiniu-upload-manager"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Rong Zhou <zhourong@qiniu.com>", "Shanghai Qiniu Information Technologies Co., Ltd."]
 edition = "2021"
 rust-version = "1.60.0"
@@ -36,9 +36,9 @@ futures = { version = "0.3.5", optional = true }
 async-once-cell = { version = "0.3.0", optional = true }
 async-std = { version = "1.10.0", optional = true }
 
-qiniu-apis = { version = "0.2.0", path = "../apis", default-features = false }
-qiniu-upload-token = { version = "0.2.0", path = "../upload-token" }
-qiniu-utils = { version = "0.2.0", path = "../utils" }
+qiniu-apis = { version = "0.2.1", path = "../apis", default-features = false }
+qiniu-upload-token = { version = "0.2.1", path = "../upload-token" }
+qiniu-utils = { version = "0.2.1", path = "../utils" }
 
 [dev-dependencies]
 env_logger = "0.9.0"

--- a/upload-manager/README.md
+++ b/upload-manager/README.md
@@ -16,21 +16,21 @@
 
 ```toml
 [dependencies]
-qiniu-upload-manager = { version = "0.2.0", features = ["ureq"] }
+qiniu-upload-manager = { version = "0.2.1", features = ["ureq"] }
 ```
 
 ### 启用 Isahc 异步接口
 
 ```toml
 [dependencies]
-qiniu-upload-manager = { version = "0.2.0", features = ["async", "isahc"] }
+qiniu-upload-manager = { version = "0.2.1", features = ["async", "isahc"] }
 ```
 
 ### 启用 Reqwest 异步接口
 
 ```toml
 [dependencies]
-qiniu-upload-manager = { version = "0.2.0", features = ["async", "reqwest"] }
+qiniu-upload-manager = { version = "0.2.1", features = ["async", "reqwest"] }
 ```
 
 ### 其他功能

--- a/upload-manager/src/multi_parts_uploader/v1.rs
+++ b/upload-manager/src/multi_parts_uploader/v1.rs
@@ -2,26 +2,22 @@ use super::{
     super::{
         callbacks::{Callbacks, UploadingProgressInfo},
         data_source::{Digestible, SourceKey},
-        upload_token::OwnedUploadTokenProviderOrReferenced,
         AppendOnlyResumableRecorderMedium, DataPartitionProvider, DataPartitionProviderFeedback, DataSourceReader,
         MultiplyDataPartitionProvider, UploaderWithCallbacks,
     },
     progress::{Progresses, ProgressesKey},
-    DataSource, InitializedParts, MultiPartsUploader, MultiPartsUploaderWithCallbacks, ObjectParams, PartsExpiredError,
-    ReinitializeOptions, ReinitializedUpEndpointsProvider, ResumableRecorder, UploadManager, UploadedPart,
+    DataSource, InitializedParts, MultiPartsUploader, MultiPartsUploaderExt, MultiPartsUploaderWithCallbacks,
+    ObjectParams, PartsExpiredError, ReinitializeOptions, ResumableRecorder, UploadManager, UploadedPart,
 };
 use anyhow::{Error as AnyError, Result as AnyResult};
 use dashmap::DashMap;
 use digest::Digest;
 use qiniu_apis::{
-    credential::AccessKey,
     http::{Reset, ResponseErrorKind as HttpResponseErrorKind, ResponseParts},
     http_client::{
-        ApiResult, BucketRegionsProvider, Endpoints, EndpointsGetOptions, EndpointsProvider, RegionsProviderEndpoints,
-        RequestBuilderParts, Response, ResponseError, ResponseErrorKind, ServiceName,
+        ApiResult, Endpoints, EndpointsProvider, RequestBuilderParts, Response, ResponseError, ResponseErrorKind,
     },
     storage::{
-        self,
         resumable_upload_v1_make_block::{
             PathParams as MkBlkPathParams, ResponseBody as MkBlkResponseBody,
             SyncRequestBuilder as SyncMkBlkRequestBuilder,
@@ -31,7 +27,7 @@ use qiniu_apis::{
         },
     },
 };
-use qiniu_upload_token::{BucketName, ObjectName};
+use qiniu_upload_token::BucketName;
 use qiniu_utils::base64::urlsafe as urlsafe_base64;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -39,7 +35,6 @@ use sha1::Sha1;
 use std::{
     fmt::{self, Debug},
     io::{BufRead, BufReader, Cursor, Read, Result as IoResult, Write},
-    mem::take,
     num::NonZeroU64,
     sync::{Arc, Mutex},
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
@@ -82,7 +77,7 @@ pub struct MultiPartsV1UploaderInitializedObject<S> {
     source: S,
     params: ObjectParams,
     progresses: Progresses,
-    recovered_records: MultiPartsV1ResumableRecorderRecords,
+    resumed_records: MultiPartsV1ResumableRecorderRecords,
 }
 
 impl<S: Clone + Debug + Send + Sync> InitializedParts for MultiPartsV1UploaderInitializedObject<S> {
@@ -90,15 +85,14 @@ impl<S: Clone + Debug + Send + Sync> InitializedParts for MultiPartsV1UploaderIn
     fn params(&self) -> &ObjectParams {
         &self.params
     }
+
+    #[inline]
+    fn up_endpoints(&self) -> &Endpoints {
+        &self.resumed_records.up_endpoints
+    }
 }
 
 impl<S> super::__private::Sealed for MultiPartsV1UploaderInitializedObject<S> {}
-
-impl<S> MultiPartsV1UploaderInitializedObject<S> {
-    fn up_endpoints(&self) -> &Endpoints {
-        &self.recovered_records.up_endpoints
-    }
-}
 
 impl<S: Debug> Debug for MultiPartsV1UploaderInitializedObject<S> {
     #[inline]
@@ -107,7 +101,7 @@ impl<S: Debug> Debug for MultiPartsV1UploaderInitializedObject<S> {
             .field("source", &self.source)
             .field("params", &self.params)
             .field("progresses", &self.progresses)
-            .field("recovered_records", &self.recovered_records)
+            .field("resumed_records", &self.resumed_records)
             .finish()
     }
 }
@@ -229,19 +223,42 @@ impl<H: Digest + Send + 'static> MultiPartsUploader for MultiPartsV1Uploader<H> 
         }
     }
 
+    #[inline]
+    fn upload_manager(&self) -> &UploadManager {
+        &self.upload_manager
+    }
+
     fn initialize_parts<D: DataSource<Self::HashAlgorithm> + 'static>(
         &self,
         source: D,
         params: ObjectParams,
     ) -> ApiResult<Self::InitializedParts> {
-        let up_endpoints = self.up_endpoints(&params)?;
-        let recovered_records = self.try_to_recover(&source, up_endpoints)?;
+        let up_endpoints = self.get_up_endpoints(&params)?;
+        let resumed_records = self.resume_or_create_records(&source, up_endpoints)?;
         Ok(Self::InitializedParts {
             source: Box::new(source),
             params,
-            recovered_records,
+            resumed_records,
             progresses: Default::default(),
         })
+    }
+
+    fn try_to_resume_parts<D: DataSource<Self::HashAlgorithm> + 'static>(
+        &self,
+        source: D,
+        params: ObjectParams,
+    ) -> Option<Self::InitializedParts> {
+        source
+            .source_key()
+            .ok()
+            .flatten()
+            .and_then(|source_key| self.try_to_resume_records(&source_key).ok().flatten())
+            .map(|resumed_records| Self::InitializedParts {
+                source: Box::new(source),
+                params,
+                resumed_records,
+                progresses: Default::default(),
+            })
     }
 
     fn reinitialize_parts(
@@ -250,19 +267,8 @@ impl<H: Digest + Send + 'static> MultiPartsUploader for MultiPartsV1Uploader<H> 
         options: ReinitializeOptions,
     ) -> ApiResult<()> {
         initialized.source.reset()?;
-        let up_endpoints = match options.endpoints_provider {
-            ReinitializedUpEndpointsProvider::KeepOriginalUpEndpoints => {
-                take(&mut initialized.recovered_records.up_endpoints)
-            }
-            ReinitializedUpEndpointsProvider::RefreshUpEndpoints => self.up_endpoints(&initialized.params)?,
-            ReinitializedUpEndpointsProvider::SpecifiedRegionsProvider(regions_provider) => {
-                let opts = EndpointsGetOptions::builder().service_names(&[ServiceName::Up]).build();
-                RegionsProviderEndpoints::new(regions_provider)
-                    .get_endpoints(opts)?
-                    .into_owned()
-            }
-        };
-        initialized.recovered_records = self.create_new_records(&initialized.source, up_endpoints)?;
+        let up_endpoints = options.get_up_endpoints(self, initialized)?;
+        initialized.resumed_records = self.create_new_records(&initialized.source, up_endpoints)?;
         initialized.progresses = Default::default();
         Ok(())
     }
@@ -278,7 +284,7 @@ impl<H: Digest + Send + 'static> MultiPartsUploader for MultiPartsV1Uploader<H> 
         return if let Some(mut reader) = initialized.source.slice(data_partitioner_provider.part_size())? {
             if let Some(part_size) = NonZeroU64::new(reader.len()?) {
                 let progresses_key = initialized.progresses.add_new_part(part_size.into());
-                if let Some(uploaded_part) = _could_recover(initialized, &mut reader, part_size) {
+                if let Some(uploaded_part) = _could_resume(initialized, &mut reader, part_size) {
                     self.after_part_uploaded(&progresses_key, total_size, Some(&uploaded_part))?;
                     Ok(Some(uploaded_part))
                 } else {
@@ -313,13 +319,13 @@ impl<H: Digest + Send + 'static> MultiPartsUploader for MultiPartsV1Uploader<H> 
             Ok(None)
         };
 
-        fn _could_recover<H: Digest>(
+        fn _could_resume<H: Digest>(
             initialized: &MultiPartsV1UploaderInitializedObject<Box<dyn DataSource<H>>>,
             data_reader: &mut DataSourceReader,
             part_size: NonZeroU64,
         ) -> Option<MultiPartsV1UploaderUploadedPart> {
             let offset = data_reader.offset();
-            initialized.recovered_records.take(offset).and_then(|record| {
+            initialized.resumed_records.take(offset).and_then(|record| {
                 if record.size == part_size
                     && record.expired_at() > SystemTime::now()
                     && Some(record.base64ed_sha1.as_str()) == sha1_of_sync_reader(data_reader).ok().as_deref()
@@ -337,7 +343,7 @@ impl<H: Digest + Send + 'static> MultiPartsUploader for MultiPartsV1Uploader<H> 
         }
 
         #[allow(clippy::too_many_arguments)]
-        fn _upload_part<'a, H: Digest, E: EndpointsProvider + Clone + 'a>(
+        fn _upload_part<'a, H: Digest + Send + 'static, E: EndpointsProvider + Clone + 'a>(
             uploader: &'a MultiPartsV1Uploader<H>,
             mut request: SyncMkBlkRequestBuilder<'a, E>,
             mut body: DataSourceReader,
@@ -379,7 +385,7 @@ impl<H: Digest + Send + 'static> MultiPartsUploader for MultiPartsV1Uploader<H> 
                 response_body,
             };
             initialized
-                .recovered_records
+                .resumed_records
                 .persist(&record, &uploader.bucket_name()?, initialized.up_endpoints())
                 .ok();
             Ok(MultiPartsV1UploaderUploadedPart::from_record(record, false))
@@ -399,7 +405,7 @@ impl<H: Digest + Send + 'static> MultiPartsUploader for MultiPartsV1Uploader<H> 
             body,
         );
 
-        fn _complete_parts<'a, H: Digest, E: EndpointsProvider + Clone + 'a, D: DataSource<H>>(
+        fn _complete_parts<'a, H: Digest + Send + 'static, E: EndpointsProvider + Clone + 'a, D: DataSource<H>>(
             uploader: &'a MultiPartsV1Uploader<H>,
             mut request: SyncMkFileRequestBuilder<'a, E>,
             source: &D,
@@ -434,14 +440,39 @@ impl<H: Digest + Send + 'static> MultiPartsUploader for MultiPartsV1Uploader<H> 
         params: ObjectParams,
     ) -> BoxFuture<ApiResult<Self::AsyncInitializedParts>> {
         Box::pin(async move {
-            let up_endpoints = self.async_up_endpoints(&params).await?;
-            let recovered_records = self.try_to_async_recover(&source, up_endpoints).await?;
+            let up_endpoints = self.async_get_up_endpoints(&params).await?;
+            let resumed_records = self.async_resume_or_create_records(&source, up_endpoints).await?;
             Ok(Self::AsyncInitializedParts {
                 source: Box::new(source),
                 params,
-                recovered_records,
+                resumed_records,
                 progresses: Default::default(),
             })
+        })
+    }
+
+    #[cfg(feature = "async")]
+    #[cfg_attr(feature = "docs", doc(cfg(feature = "async")))]
+    fn try_to_async_resume_parts<D: AsyncDataSource<Self::HashAlgorithm> + 'static>(
+        &self,
+        source: D,
+        params: ObjectParams,
+    ) -> BoxFuture<Option<Self::AsyncInitializedParts>> {
+        Box::pin(async move {
+            if let Some(source_key) = source.source_key().await.ok().flatten() {
+                self.try_to_async_resume_records(&source_key)
+                    .await
+                    .ok()
+                    .flatten()
+                    .map(|resumed_records| Self::AsyncInitializedParts {
+                        source: Box::new(source),
+                        params,
+                        resumed_records,
+                        progresses: Default::default(),
+                    })
+            } else {
+                None
+            }
         })
     }
 
@@ -454,22 +485,8 @@ impl<H: Digest + Send + 'static> MultiPartsUploader for MultiPartsV1Uploader<H> 
     ) -> BoxFuture<'r, ApiResult<()>> {
         Box::pin(async move {
             initialized.source.reset().await?;
-            let up_endpoints = match options.endpoints_provider {
-                ReinitializedUpEndpointsProvider::KeepOriginalUpEndpoints => {
-                    take(&mut initialized.recovered_records.up_endpoints)
-                }
-                ReinitializedUpEndpointsProvider::RefreshUpEndpoints => {
-                    self.async_up_endpoints(&initialized.params).await?
-                }
-                ReinitializedUpEndpointsProvider::SpecifiedRegionsProvider(regions_provider) => {
-                    let opts = EndpointsGetOptions::builder().service_names(&[ServiceName::Up]).build();
-                    RegionsProviderEndpoints::new(regions_provider)
-                        .async_get_endpoints(opts)
-                        .await?
-                        .into_owned()
-                }
-            };
-            initialized.recovered_records = self.async_create_new_records(&initialized.source, up_endpoints).await?;
+            let up_endpoints = options.async_get_up_endpoints(self, initialized).await?;
+            initialized.resumed_records = self.async_create_new_records(&initialized.source, up_endpoints).await?;
             initialized.progresses = Default::default();
             Ok(())
         })
@@ -489,7 +506,7 @@ impl<H: Digest + Send + 'static> MultiPartsUploader for MultiPartsV1Uploader<H> 
             if let Some(mut reader) = initialized.source.slice(data_partitioner_provider.part_size()).await? {
                 if let Some(part_size) = NonZeroU64::new(reader.len().await?) {
                     let progresses_key = initialized.progresses.add_new_part(part_size.into());
-                    if let Some(uploaded_part) = _could_recover(initialized, &mut reader, part_size).await {
+                    if let Some(uploaded_part) = _could_resume(initialized, &mut reader, part_size).await {
                         self.after_part_uploaded(&progresses_key, total_size, Some(&uploaded_part))?;
                         Ok(Some(uploaded_part))
                     } else {
@@ -526,13 +543,13 @@ impl<H: Digest + Send + 'static> MultiPartsUploader for MultiPartsV1Uploader<H> 
             }
         });
 
-        async fn _could_recover<H: Digest>(
+        async fn _could_resume<H: Digest>(
             initialized: &MultiPartsV1UploaderInitializedObject<Box<dyn AsyncDataSource<H>>>,
             data_reader: &mut AsyncDataSourceReader,
             part_size: NonZeroU64,
         ) -> Option<MultiPartsV1UploaderUploadedPart> {
             let offset = data_reader.offset();
-            OptionFuture::from(initialized.recovered_records.take(offset).map(|record| async move {
+            OptionFuture::from(initialized.resumed_records.take(offset).map(|record| async move {
                 if record.size == part_size
                     && record.expired_at() > SystemTime::now()
                     && Some(record.base64ed_sha1.as_str()) == sha1_of_async_reader(data_reader).await.ok().as_deref()
@@ -552,7 +569,7 @@ impl<H: Digest + Send + 'static> MultiPartsUploader for MultiPartsV1Uploader<H> 
         }
 
         #[allow(clippy::too_many_arguments)]
-        async fn _upload_part<'a, H: Digest, E: EndpointsProvider + Clone + 'a>(
+        async fn _upload_part<'a, H: Digest + Send + 'static, E: EndpointsProvider + Clone + 'a>(
             uploader: &'a MultiPartsV1Uploader<H>,
             mut request: AsyncMkBlkRequestBuilder<'a, E>,
             mut body: AsyncDataSourceReader,
@@ -594,7 +611,7 @@ impl<H: Digest + Send + 'static> MultiPartsUploader for MultiPartsV1Uploader<H> 
                 response_body,
             };
             initialized
-                .recovered_records
+                .resumed_records
                 .async_persist(
                     &record,
                     &uploader.async_bucket_name().await?,
@@ -628,7 +645,12 @@ impl<H: Digest + Send + 'static> MultiPartsUploader for MultiPartsV1Uploader<H> 
             .await
         });
 
-        async fn _complete_parts<'a, H: Digest, E: EndpointsProvider + Clone + 'a, D: AsyncDataSource<H>>(
+        async fn _complete_parts<
+            'a,
+            H: Digest + Send + 'static,
+            E: EndpointsProvider + Clone + 'a,
+            D: AsyncDataSource<H>,
+        >(
             uploader: &'a MultiPartsV1Uploader<H>,
             mut request: AsyncMkFileRequestBuilder<'a, E>,
             source: &D,
@@ -712,29 +734,7 @@ fn may_set_extensions_in_err(err: &mut ResponseError) {
     }
 }
 
-impl<H: Digest> MultiPartsV1Uploader<H> {
-    fn storage(&self) -> storage::Client {
-        self.upload_manager.client().storage()
-    }
-
-    fn access_key(&self) -> ApiResult<AccessKey> {
-        self.upload_manager.upload_token().access_key()
-    }
-
-    fn bucket_name(&self) -> ApiResult<BucketName> {
-        self.upload_manager.upload_token().bucket_name()
-    }
-
-    #[cfg(feature = "async")]
-    async fn async_access_key(&self) -> ApiResult<AccessKey> {
-        self.upload_manager.upload_token().async_access_key().await
-    }
-
-    #[cfg(feature = "async")]
-    async fn async_bucket_name(&self) -> ApiResult<BucketName> {
-        self.upload_manager.upload_token().async_bucket_name().await
-    }
-
+impl<H: Digest + Send + 'static> MultiPartsV1Uploader<H> {
     fn before_request_call(&self, request: &mut RequestBuilderParts<'_>) -> ApiResult<()> {
         self.callbacks.before_request(request).map_err(make_callback_error)
     }
@@ -764,103 +764,49 @@ impl<H: Digest> MultiPartsV1Uploader<H> {
             ))
             .map_err(make_callback_error)
     }
-}
 
-impl<H: Digest> MultiPartsV1Uploader<H> {
-    fn up_endpoints(&self, params: &ObjectParams) -> ApiResult<Endpoints> {
-        let options = EndpointsGetOptions::builder().service_names(&[ServiceName::Up]).build();
-        let up_endpoints = if let Some(region_provider) = params.region_provider() {
-            RegionsProviderEndpoints::new(region_provider)
-                .get_endpoints(options)?
-                .into_owned()
-        } else {
-            RegionsProviderEndpoints::new(self.get_bucket_region()?)
-                .get_endpoints(options)?
-                .into_owned()
-        };
-        Ok(up_endpoints)
-    }
-
-    #[cfg(feature = "async")]
-    async fn async_up_endpoints(&self, params: &ObjectParams) -> ApiResult<Endpoints> {
-        let options = EndpointsGetOptions::builder().service_names(&[ServiceName::Up]).build();
-        let up_endpoints = if let Some(region_provider) = params.region_provider() {
-            RegionsProviderEndpoints::new(region_provider)
-                .async_get_endpoints(options)
-                .await?
-                .into_owned()
-        } else {
-            RegionsProviderEndpoints::new(self.async_get_bucket_region().await?)
-                .async_get_endpoints(options)
-                .await?
-                .into_owned()
-        };
-        Ok(up_endpoints)
-    }
-
-    fn get_bucket_region(&self) -> ApiResult<BucketRegionsProvider> {
-        Ok(self
-            .upload_manager
-            .queryer()
-            .query(self.access_key()?, self.bucket_name()?))
-    }
-
-    #[cfg(feature = "async")]
-    async fn async_get_bucket_region(&self) -> ApiResult<BucketRegionsProvider> {
-        Ok(self
-            .upload_manager
-            .queryer()
-            .query(self.async_access_key().await?, self.async_bucket_name().await?))
-    }
-
-    fn make_upload_token_signer(&self, object_name: Option<ObjectName>) -> OwnedUploadTokenProviderOrReferenced<'_> {
-        self.upload_manager
-            .upload_token()
-            .make_upload_token_provider(object_name)
-    }
-
-    fn try_to_recover<D: DataSource<H>>(
+    fn resume_or_create_records<D: DataSource<H>>(
         &self,
         source: &D,
         up_endpoints: Endpoints,
     ) -> IoResult<MultiPartsV1ResumableRecorderRecords> {
         let records = if let Some(source_key) = source.source_key()? {
-            _try_to_recover(self, &source_key)
+            self.try_to_resume_records(&source_key)
                 .ok()
                 .flatten()
                 .unwrap_or_else(|| _create_new_records(&self.resumable_recorder, &source_key, up_endpoints))
         } else {
             MultiPartsV1ResumableRecorderRecords::new(up_endpoints)
         };
-        return Ok(records);
+        Ok(records)
+    }
 
-        fn _try_to_recover<H: Digest>(
-            uploader: &MultiPartsV1Uploader<H>,
-            source_key: &SourceKey<H>,
-        ) -> ApiResult<Option<MultiPartsV1ResumableRecorderRecords>> {
-            let mut medium = uploader.resumable_recorder.open_for_read(source_key)?;
-            let mut lines = BufReader::new(&mut medium).lines();
-            let header = if let Some(line) = lines.next() {
-                let line = line?;
-                let header: MultiPartsV1ResumableRecorderDeserializableHeader = serde_json::from_str(&line)?;
-                if !header.is_v1() || header.bucket() != uploader.bucket_name()?.as_str() {
-                    return Ok(None);
-                }
-                header
-            } else {
+    fn try_to_resume_records(
+        &self,
+        source_key: &SourceKey<H>,
+    ) -> ApiResult<Option<MultiPartsV1ResumableRecorderRecords>> {
+        let mut medium = self.resumable_recorder.open_for_read(source_key)?;
+        let mut lines = BufReader::new(&mut medium).lines();
+        let header = if let Some(line) = lines.next() {
+            let line = line?;
+            let header: MultiPartsV1ResumableRecorderDeserializableHeader = serde_json::from_str(&line)?;
+            if !header.is_v1() || header.bucket() != self.bucket_name()?.as_str() {
                 return Ok(None);
-            };
-            let mut records = lines
-                .map(|line| {
-                    let line = line?;
-                    let record: MultiPartsV1ResumableRecorderRecord = serde_json::from_str(&line)?;
-                    Ok(record)
-                })
-                .collect::<ApiResult<MultiPartsV1ResumableRecorderRecords>>()?;
-            records.up_endpoints = header.up_endpoints;
-            records.set_medium_for_append(uploader.resumable_recorder.open_for_append(source_key)?, true);
-            Ok(Some(records))
-        }
+            }
+            header
+        } else {
+            return Ok(None);
+        };
+        let mut records = lines
+            .map(|line| {
+                let line = line?;
+                let record: MultiPartsV1ResumableRecorderRecord = serde_json::from_str(&line)?;
+                Ok(record)
+            })
+            .collect::<ApiResult<MultiPartsV1ResumableRecorderRecords>>()?;
+        records.up_endpoints = header.up_endpoints;
+        records.set_medium_for_append(self.resumable_recorder.open_for_append(source_key)?, true);
+        Ok(Some(records))
     }
 
     fn create_new_records<D: DataSource<H>>(
@@ -877,13 +823,13 @@ impl<H: Digest> MultiPartsV1Uploader<H> {
     }
 
     #[cfg(feature = "async")]
-    async fn try_to_async_recover<D: AsyncDataSource<H>>(
+    async fn async_resume_or_create_records<D: AsyncDataSource<H>>(
         &self,
         source: &D,
         up_endpoints: Endpoints,
     ) -> IoResult<MultiPartsV1ResumableRecorderRecords> {
         let records = if let Some(source_key) = source.source_key().await? {
-            if let Some(records) = _try_to_recover(self, &source_key).await.ok().flatten() {
+            if let Some(records) = self.try_to_async_resume_records(&source_key).await.ok().flatten() {
                 records
             } else {
                 _async_create_new_records(&self.resumable_recorder, &source_key, up_endpoints).await
@@ -891,38 +837,36 @@ impl<H: Digest> MultiPartsV1Uploader<H> {
         } else {
             MultiPartsV1ResumableRecorderRecords::new(up_endpoints)
         };
-        return Ok(records);
+        Ok(records)
+    }
 
-        async fn _try_to_recover<H: Digest>(
-            uploader: &MultiPartsV1Uploader<H>,
-            source_key: &SourceKey<H>,
-        ) -> ApiResult<Option<MultiPartsV1ResumableRecorderRecords>> {
-            let mut medium = uploader.resumable_recorder.open_for_async_read(source_key).await?;
-            let mut lines = AsyncBufReader::new(&mut medium).lines();
-            let header = if let Some(line) = lines.try_next().await? {
-                let header: MultiPartsV1ResumableRecorderDeserializableHeader = serde_json::from_str(&line)?;
-                if !header.is_v1() || header.bucket() != uploader.async_bucket_name().await?.as_str() {
-                    return Ok(None);
-                }
-                header
-            } else {
+    #[cfg(feature = "async")]
+    async fn try_to_async_resume_records(
+        &self,
+        source_key: &SourceKey<H>,
+    ) -> ApiResult<Option<MultiPartsV1ResumableRecorderRecords>> {
+        let mut medium = self.resumable_recorder.open_for_async_read(source_key).await?;
+        let mut lines = AsyncBufReader::new(&mut medium).lines();
+        let header = if let Some(line) = lines.try_next().await? {
+            let header: MultiPartsV1ResumableRecorderDeserializableHeader = serde_json::from_str(&line)?;
+            if !header.is_v1() || header.bucket() != self.async_bucket_name().await?.as_str() {
                 return Ok(None);
-            };
-            let mut records = lines
-                .map(|line| {
-                    let line = line?;
-                    let record: MultiPartsV1ResumableRecorderRecord = serde_json::from_str(&line)?;
-                    Ok::<_, ResponseError>(record)
-                })
-                .try_collect::<MultiPartsV1ResumableRecorderRecords>()
-                .await?;
-            records.up_endpoints = header.up_endpoints;
-            records.set_medium_for_async_append(
-                uploader.resumable_recorder.open_for_async_append(source_key).await?,
-                true,
-            );
-            Ok(Some(records))
-        }
+            }
+            header
+        } else {
+            return Ok(None);
+        };
+        let mut records = lines
+            .map(|line| {
+                let line = line?;
+                let record: MultiPartsV1ResumableRecorderRecord = serde_json::from_str(&line)?;
+                Ok::<_, ResponseError>(record)
+            })
+            .try_collect::<MultiPartsV1ResumableRecorderRecords>()
+            .await?;
+        records.up_endpoints = header.up_endpoints;
+        records.set_medium_for_async_append(self.resumable_recorder.open_for_async_append(source_key).await?, true);
+        Ok(Some(records))
     }
 
     #[cfg(feature = "async")]
@@ -1517,6 +1461,9 @@ mod tests {
                 let params = ObjectParams::builder()
                     .region_provider(single_up_domain_region())
                     .build();
+                assert!(uploader
+                    .try_to_resume_parts(file_source.to_owned(), params.to_owned())
+                    .is_none());
                 let initialized_parts = uploader.initialize_parts(file_source, params)?;
                 uploader
                     .upload_part(&initialized_parts, &new_data_partitioner_provider(BLOCK_SIZE))?
@@ -1644,6 +1591,8 @@ mod tests {
         #[cfg(feature = "async")]
         #[async_std::test]
         async fn test_async_multi_parts_v1_upload_with_recovery() -> Result<()> {
+            use async_std::fs::read_dir as async_read_dir;
+
             env_logger::builder().is_test(true).try_init().ok();
 
             #[derive(Debug)]
@@ -1711,6 +1660,10 @@ mod tests {
                 let params = ObjectParams::builder()
                     .region_provider(single_up_domain_region())
                     .build();
+                assert!(uploader
+                    .try_to_async_resume_parts(file_source.to_owned(), params.to_owned())
+                    .await
+                    .is_none());
                 let initialized_parts = uploader.async_initialize_parts(file_source, params).await?;
                 uploader
                     .async_upload_part(&initialized_parts, &new_data_partitioner_provider(BLOCK_SIZE))
@@ -1726,7 +1679,7 @@ mod tests {
                 let params = ObjectParams::builder()
                     .region_provider(single_up_domain_region())
                     .build();
-                let initialized_parts = uploader.async_initialize_parts(file_source, params).await?;
+                let initialized_parts = uploader.try_to_async_resume_parts(file_source, params).await.unwrap();
                 for _ in 0..2 {
                     uploader
                         .async_upload_part(&initialized_parts, &new_data_partitioner_provider(BLOCK_SIZE))
@@ -1805,7 +1758,7 @@ mod tests {
                 }
             }
 
-            {
+            let mut initialized_parts = {
                 let uploader = Arc::new(MultiPartsV1Uploader::new(
                     get_upload_manager(FakeHttpCaller2::new(2)),
                     FileSystemResumableRecorder::<Sha1>::new(resuming_files_dir.path()),
@@ -1828,13 +1781,100 @@ mod tests {
                 let parts = parts.into_iter().map(|part| part.unwrap()).collect::<Vec<_>>();
                 let body = uploader.async_complete_parts(&initialized_parts, &parts).await?;
                 assert_eq!(body.get("done").unwrap().as_u64().unwrap(), 1u64);
+                Arc::try_unwrap(initialized_parts).unwrap()
+            };
+
+            assert!(async_read_dir(resuming_files_dir.path()).await?.next().await.is_none());
+
+            #[derive(Debug)]
+            struct FakeHttpCaller3 {
+                mkblk_counts: AtomicUsize,
+                mkfile_counts: AtomicUsize,
             }
 
-            assert!(async_std::fs::read_dir(resuming_files_dir.path())
-                .await?
-                .next()
-                .await
-                .is_none());
+            impl FakeHttpCaller3 {
+                fn new() -> Self {
+                    Self {
+                        mkblk_counts: Default::default(),
+                        mkfile_counts: Default::default(),
+                    }
+                }
+            }
+
+            impl HttpCaller for FakeHttpCaller3 {
+                fn call(&self, _request: &mut SyncRequest<'_>) -> SyncResponseResult {
+                    unreachable!()
+                }
+
+                fn async_call<'a>(&'a self, request: &'a mut AsyncRequest<'_>) -> BoxFuture<'a, AsyncResponseResult> {
+                    Box::pin(async move {
+                        let resp_body = if request.url().path().starts_with("/mkblk/") {
+                            let blk_size: u64;
+                            scan_text!(request.url().path().bytes() => "/mkblk/{}", blk_size);
+
+                            match blk_size {
+                                BLOCK_SIZE | LAST_BLOCK_SIZE => {
+                                    self.mkblk_counts.fetch_add(1, Ordering::Relaxed);
+                                }
+                                _ => unreachable!(),
+                            }
+                            let body_len = size_of_async_reader(request.body_mut()).await.unwrap();
+                            assert_eq!(body_len, blk_size);
+                            json_to_vec(&json!({
+                                "ctx": format!("==={}===", self.mkblk_counts.load(Ordering::Relaxed)),
+                                "checksum": sha1_of_async_reader(request.body_mut()).await.unwrap(),
+                                "offset": blk_size,
+                                "host": "http://fakeexample.com",
+                                "expired_at": (SystemTime::now() + Duration::from_secs(3600)).duration_since(UNIX_EPOCH).unwrap().as_secs(),
+                            }))
+                            .unwrap()
+                        } else if request.url().path().starts_with("/mkfile/") {
+                            assert_eq!(self.mkblk_counts.load(Ordering::Relaxed), 3);
+                            assert_eq!(self.mkfile_counts.fetch_add(1, Ordering::Relaxed), 0);
+                            assert_eq!(request.url().path(), &format!("/mkfile/{}", FILE_SIZE));
+                            let mut req_body = Vec::new();
+                            async_io_copy(request.body_mut(), &mut req_body).await.unwrap();
+                            assert_eq!(String::from_utf8(req_body).unwrap().split(',').count(), BLOCK_COUNT);
+                            json_to_vec(&json!({
+                                "done": 1,
+                            }))
+                            .unwrap()
+                        } else {
+                            unreachable!()
+                        };
+                        Ok(AsyncResponse::builder()
+                            .status_code(StatusCode::OK)
+                            .header("x-reqid", HeaderValue::from_static("FakeReqid"))
+                            .body(AsyncResponseBody::from_bytes(resp_body))
+                            .build())
+                    })
+                }
+            }
+
+            {
+                let uploader = Arc::new(MultiPartsV1Uploader::new(
+                    get_upload_manager(FakeHttpCaller3::new()),
+                    FileSystemResumableRecorder::<Sha1>::new(resuming_files_dir.path()),
+                ));
+                uploader
+                    .async_reinitialize_parts(&mut initialized_parts, Default::default())
+                    .await?;
+                let initialized_parts = Arc::new(initialized_parts);
+                let tasks = (0..BLOCK_COUNT).map(|_| {
+                    let uploader = uploader.to_owned();
+                    let initialized_parts = initialized_parts.to_owned();
+                    spawn_task(async move {
+                        uploader
+                            .async_upload_part(&initialized_parts, &new_data_partitioner_provider(BLOCK_SIZE))
+                            .await
+                    })
+                });
+                let parts = join_all(tasks).await.into_iter().collect::<ApiResult<Vec<_>>>()?;
+                let parts = parts.into_iter().map(|part| part.unwrap()).collect::<Vec<_>>();
+                let body = uploader.async_complete_parts(&initialized_parts, &parts).await?;
+                assert_eq!(body.get("done").unwrap().as_u64().unwrap(), 1u64);
+            }
+
             Ok(())
         }
     }

--- a/upload-manager/src/multi_parts_uploader/v2.rs
+++ b/upload-manager/src/multi_parts_uploader/v2.rs
@@ -2,28 +2,24 @@ use super::{
     super::{
         callbacks::{Callbacks, UploadingProgressInfo},
         data_source::{Digestible, SourceKey},
-        upload_token::OwnedUploadTokenProviderOrReferenced,
         AppendOnlyResumableRecorderMedium, DataPartitionProvider, DataPartitionProviderFeedback, DataSourceReader,
         LimitedDataPartitionProvider, UploaderWithCallbacks,
     },
     progress::{Progresses, ProgressesKey},
     v1::make_callback_error,
-    DataSource, InitializedParts, MultiPartsUploader, MultiPartsUploaderWithCallbacks, ObjectParams, PartsExpiredError,
-    ReinitializeOptions, ReinitializedUpEndpointsProvider, ResumableRecorder, UploadManager, UploadedPart,
+    DataSource, InitializedParts, MultiPartsUploader, MultiPartsUploaderExt, MultiPartsUploaderWithCallbacks,
+    ObjectParams, PartsExpiredError, ReinitializeOptions, ResumableRecorder, UploadManager, UploadedPart,
 };
 use anyhow::Result as AnyResult;
 use dashmap::DashMap;
 use digest::Digest;
 use qiniu_apis::{
     base_types::StringMap,
-    credential::AccessKey,
     http::{Reset, ResponseParts},
     http_client::{
-        ApiResult, BucketRegionsProvider, Endpoints, EndpointsGetOptions, EndpointsProvider, RegionsProviderEndpoints,
-        RequestBuilderParts, Response, ResponseError, ResponseErrorKind, ServiceName,
+        ApiResult, Endpoints, EndpointsProvider, RequestBuilderParts, Response, ResponseError, ResponseErrorKind,
     },
     storage::{
-        self,
         resumable_upload_v2_complete_multipart_upload::{
             PartInfo, PathParams as CompletePartsPathParams, RequestBody as CompletePartsRequestBody,
             SyncRequestBuilder as SyncCompletePartsRequestBuilder,
@@ -90,7 +86,7 @@ pub struct MultiPartsV2UploaderInitializedObject<S> {
     source: S,
     params: ObjectParams,
     progresses: Progresses,
-    recovered_records: MultiPartsV2ResumableRecorderRecords,
+    resumed_records: MultiPartsV2ResumableRecorderRecords,
     info: MultiPartsV2UploaderInitializedResponseInfo,
 }
 
@@ -106,10 +102,6 @@ impl<S> MultiPartsV2UploaderInitializedObject<S> {
     pub fn expired_at(&self) -> SystemTime {
         self.info.expired_at
     }
-
-    fn up_endpoints(&self) -> &Endpoints {
-        &self.recovered_records.up_endpoints
-    }
 }
 
 #[derive(Debug, Clone)]
@@ -123,6 +115,11 @@ impl<S: Clone + Debug + Send + Sync> InitializedParts for MultiPartsV2UploaderIn
     fn params(&self) -> &ObjectParams {
         &self.params
     }
+
+    #[inline]
+    fn up_endpoints(&self) -> &Endpoints {
+        &self.resumed_records.up_endpoints
+    }
 }
 
 impl<S> super::__private::Sealed for MultiPartsV2UploaderInitializedObject<S> {}
@@ -135,7 +132,7 @@ impl<S: Debug> Debug for MultiPartsV2UploaderInitializedObject<S> {
             .field("source", &self.source)
             .field("params", &self.params)
             .field("progresses", &self.progresses)
-            .field("recovered_records", &self.recovered_records)
+            .field("resumed_records", &self.resumed_records)
             .finish()
     }
 }
@@ -264,14 +261,20 @@ impl<H: Digest + Send + 'static> MultiPartsUploader for MultiPartsV2Uploader<H> 
         }
     }
 
+    #[inline]
+    fn upload_manager(&self) -> &UploadManager {
+        &self.upload_manager
+    }
+
     fn initialize_parts<D: DataSource<Self::HashAlgorithm> + 'static>(
         &self,
         source: D,
         params: ObjectParams,
     ) -> ApiResult<Self::InitializedParts> {
-        let (info, recovered_records) = self.try_to_recover(&source, &params, self.up_endpoints(&params)?)?;
+        let (info, resumed_records) =
+            self.resume_or_create_records(&source, &params, self.get_up_endpoints(&params)?)?;
         let info = info.map_or_else(
-            || self.call_initialize_parts(&params, &recovered_records.up_endpoints),
+            || self.call_initialize_parts(&params, &resumed_records.up_endpoints),
             Ok,
         )?;
 
@@ -279,9 +282,28 @@ impl<H: Digest + Send + 'static> MultiPartsUploader for MultiPartsV2Uploader<H> 
             source: Box::new(source),
             params,
             info,
-            recovered_records,
+            resumed_records,
             progresses: Default::default(),
         })
+    }
+
+    fn try_to_resume_parts<D: DataSource<Self::HashAlgorithm> + 'static>(
+        &self,
+        source: D,
+        params: ObjectParams,
+    ) -> Option<Self::InitializedParts> {
+        source
+            .source_key()
+            .ok()
+            .flatten()
+            .and_then(|source_key| self.try_to_resume_records(&source_key, &params).ok().flatten())
+            .map(|(info, resumed_records)| Self::InitializedParts {
+                source: Box::new(source),
+                params,
+                info,
+                resumed_records,
+                progresses: Default::default(),
+            })
     }
 
     fn reinitialize_parts(
@@ -290,19 +312,8 @@ impl<H: Digest + Send + 'static> MultiPartsUploader for MultiPartsV2Uploader<H> 
         options: ReinitializeOptions,
     ) -> ApiResult<()> {
         initialized.source.reset()?;
-        let up_endpoints = match options.endpoints_provider {
-            ReinitializedUpEndpointsProvider::KeepOriginalUpEndpoints => {
-                take(&mut initialized.recovered_records.up_endpoints)
-            }
-            ReinitializedUpEndpointsProvider::RefreshUpEndpoints => self.up_endpoints(&initialized.params)?,
-            ReinitializedUpEndpointsProvider::SpecifiedRegionsProvider(regions_provider) => {
-                let opts = EndpointsGetOptions::builder().service_names(&[ServiceName::Up]).build();
-                RegionsProviderEndpoints::new(regions_provider)
-                    .get_endpoints(opts)?
-                    .into_owned()
-            }
-        };
-        initialized.recovered_records = self.create_new_records(&initialized.source, up_endpoints)?;
+        let up_endpoints = options.get_up_endpoints(self, initialized)?;
+        initialized.resumed_records = self.create_new_records(&initialized.source, up_endpoints)?;
         initialized.info = self.call_initialize_parts(&initialized.params, initialized.up_endpoints())?;
         initialized.progresses = Default::default();
         Ok(())
@@ -322,7 +333,7 @@ impl<H: Digest + Send + 'static> MultiPartsUploader for MultiPartsV2Uploader<H> 
         return if let Some(mut reader) = initialized.source.slice(data_partitioner_provider.part_size())? {
             if let Some(part_size) = NonZeroU64::new(reader.len()?) {
                 let progresses_key = initialized.progresses.add_new_part(part_size.into());
-                if let Some(uploaded_part) = _could_recover(initialized, &mut reader, part_size) {
+                if let Some(uploaded_part) = _could_resume(initialized, &mut reader, part_size) {
                     self.after_part_uploaded(&progresses_key, total_size, Some(&uploaded_part))?;
                     Ok(Some(uploaded_part))
                 } else {
@@ -363,13 +374,13 @@ impl<H: Digest + Send + 'static> MultiPartsUploader for MultiPartsV2Uploader<H> 
             Ok(None)
         };
 
-        fn _could_recover<H: Digest>(
+        fn _could_resume<H: Digest>(
             initialized: &MultiPartsV2UploaderInitializedObject<Box<dyn DataSource<H>>>,
             data_reader: &mut DataSourceReader,
             part_size: NonZeroU64,
         ) -> Option<MultiPartsV2UploaderUploadedPart> {
             let offset = data_reader.offset();
-            initialized.recovered_records.take(offset).and_then(|record| {
+            initialized.resumed_records.take(offset).and_then(|record| {
                 if record.size == part_size
                     && record.part_number == data_reader.part_number()
                     && Some(record.base64ed_sha1.as_str()) == sha1_of_sync_reader(data_reader).ok().as_deref()
@@ -387,7 +398,7 @@ impl<H: Digest + Send + 'static> MultiPartsUploader for MultiPartsV2Uploader<H> 
             })
         }
 
-        fn _upload_part<'a, H: Digest, E: EndpointsProvider + Clone + 'a>(
+        fn _upload_part<'a, H: Digest + Send + 'static, E: EndpointsProvider + Clone + 'a>(
             uploader: &'a MultiPartsV2Uploader<H>,
             mut request: SyncUploadPartRequestBuilder<'a, E>,
             mut body: DataSourceReader,
@@ -427,7 +438,7 @@ impl<H: Digest + Send + 'static> MultiPartsUploader for MultiPartsV2Uploader<H> 
                 part_number,
             };
             initialized
-                .recovered_records
+                .resumed_records
                 .persist(
                     &initialized.info,
                     &record,
@@ -456,7 +467,7 @@ impl<H: Digest + Send + 'static> MultiPartsUploader for MultiPartsV2Uploader<H> 
             body,
         );
 
-        fn _complete_parts<'a, H: Digest, E: EndpointsProvider + Clone + 'a, D: DataSource<H>>(
+        fn _complete_parts<'a, H: Digest + Send + 'static, E: EndpointsProvider + Clone + 'a, D: DataSource<H>>(
             uploader: &'a MultiPartsV2Uploader<H>,
             mut request: SyncCompletePartsRequestBuilder<'a, E>,
             source: &D,
@@ -490,13 +501,13 @@ impl<H: Digest + Send + 'static> MultiPartsUploader for MultiPartsV2Uploader<H> 
         params: ObjectParams,
     ) -> BoxFuture<ApiResult<Self::AsyncInitializedParts>> {
         Box::pin(async move {
-            let (info, recovered_records) = self
-                .try_to_async_recover(&source, &params, self.async_up_endpoints(&params).await?)
+            let (info, resumed_records) = self
+                .async_resume_or_create_records(&source, &params, self.async_get_up_endpoints(&params).await?)
                 .await?;
             let info = if let Some(info) = info {
                 info
             } else {
-                self.async_call_initialize_parts(&params, &recovered_records.up_endpoints)
+                self.async_call_initialize_parts(&params, &resumed_records.up_endpoints)
                     .await?
             };
 
@@ -504,9 +515,35 @@ impl<H: Digest + Send + 'static> MultiPartsUploader for MultiPartsV2Uploader<H> 
                 source: Box::new(source),
                 params,
                 info,
-                recovered_records,
+                resumed_records,
                 progresses: Default::default(),
             })
+        })
+    }
+
+    #[cfg(feature = "async")]
+    #[cfg_attr(feature = "docs", doc(cfg(feature = "async")))]
+    fn try_to_async_resume_parts<D: AsyncDataSource<Self::HashAlgorithm> + 'static>(
+        &self,
+        source: D,
+        params: ObjectParams,
+    ) -> BoxFuture<Option<Self::AsyncInitializedParts>> {
+        Box::pin(async move {
+            if let Some(source_key) = source.source_key().await.ok().flatten() {
+                self.try_to_async_resume_records(&source_key, &params)
+                    .await
+                    .ok()
+                    .flatten()
+                    .map(|(info, resumed_records)| Self::AsyncInitializedParts {
+                        source: Box::new(source),
+                        params,
+                        info,
+                        resumed_records,
+                        progresses: Default::default(),
+                    })
+            } else {
+                None
+            }
         })
     }
 
@@ -519,22 +556,8 @@ impl<H: Digest + Send + 'static> MultiPartsUploader for MultiPartsV2Uploader<H> 
     ) -> BoxFuture<ApiResult<()>> {
         Box::pin(async move {
             initialized.source.reset().await?;
-            let up_endpoints = match options.endpoints_provider {
-                ReinitializedUpEndpointsProvider::KeepOriginalUpEndpoints => {
-                    take(&mut initialized.recovered_records.up_endpoints)
-                }
-                ReinitializedUpEndpointsProvider::RefreshUpEndpoints => {
-                    self.async_up_endpoints(&initialized.params).await?
-                }
-                ReinitializedUpEndpointsProvider::SpecifiedRegionsProvider(regions_provider) => {
-                    let opts = EndpointsGetOptions::builder().service_names(&[ServiceName::Up]).build();
-                    RegionsProviderEndpoints::new(regions_provider)
-                        .async_get_endpoints(opts)
-                        .await?
-                        .into_owned()
-                }
-            };
-            initialized.recovered_records = self.async_create_new_records(&initialized.source, up_endpoints).await?;
+            let up_endpoints = options.async_get_up_endpoints(self, initialized).await?;
+            initialized.resumed_records = self.async_create_new_records(&initialized.source, up_endpoints).await?;
             initialized.info = self
                 .async_call_initialize_parts(&initialized.params, initialized.up_endpoints())
                 .await?;
@@ -560,7 +583,7 @@ impl<H: Digest + Send + 'static> MultiPartsUploader for MultiPartsV2Uploader<H> 
             if let Some(mut reader) = initialized.source.slice(data_partitioner_provider.part_size()).await? {
                 if let Some(part_size) = NonZeroU64::new(reader.len().await?) {
                     let progresses_key = initialized.progresses.add_new_part(part_size.get());
-                    if let Some(uploaded_part) = _could_recover(initialized, &mut reader, part_size).await {
+                    if let Some(uploaded_part) = _could_resume(initialized, &mut reader, part_size).await {
                         self.after_part_uploaded(&progresses_key, total_size, Some(&uploaded_part))?;
                         Ok(Some(uploaded_part))
                     } else {
@@ -606,13 +629,13 @@ impl<H: Digest + Send + 'static> MultiPartsUploader for MultiPartsV2Uploader<H> 
             }
         });
 
-        async fn _could_recover<H: Digest>(
+        async fn _could_resume<H: Digest>(
             initialized: &MultiPartsV2UploaderInitializedObject<Box<dyn AsyncDataSource<H>>>,
             data_reader: &mut AsyncDataSourceReader,
             part_size: NonZeroU64,
         ) -> Option<MultiPartsV2UploaderUploadedPart> {
             let offset = data_reader.offset();
-            OptionFuture::from(initialized.recovered_records.take(offset).map(|record| async move {
+            OptionFuture::from(initialized.resumed_records.take(offset).map(|record| async move {
                 if record.size == part_size
                     && record.part_number == data_reader.part_number()
                     && Some(record.base64ed_sha1.as_str()) == sha1_of_async_reader(data_reader).await.ok().as_deref()
@@ -632,7 +655,7 @@ impl<H: Digest + Send + 'static> MultiPartsUploader for MultiPartsV2Uploader<H> 
             .flatten()
         }
 
-        async fn _upload_part<'a, H: Digest, E: EndpointsProvider + Clone + 'a>(
+        async fn _upload_part<'a, H: Digest + Send + 'static, E: EndpointsProvider + Clone + 'a>(
             uploader: &'a MultiPartsV2Uploader<H>,
             mut request: AsyncUploadPartRequestBuilder<'a, E>,
             mut body: AsyncDataSourceReader,
@@ -672,7 +695,7 @@ impl<H: Digest + Send + 'static> MultiPartsUploader for MultiPartsV2Uploader<H> 
                 part_number,
             };
             initialized
-                .recovered_records
+                .resumed_records
                 .async_persist(
                     &initialized.info,
                     &record,
@@ -711,7 +734,12 @@ impl<H: Digest + Send + 'static> MultiPartsUploader for MultiPartsV2Uploader<H> 
             .await
         });
 
-        async fn _complete_parts<'a, H: Digest, E: EndpointsProvider + Clone + 'a, D: AsyncDataSource<H>>(
+        async fn _complete_parts<
+            'a,
+            H: Digest + Send + 'static,
+            E: EndpointsProvider + Clone + 'a,
+            D: AsyncDataSource<H>,
+        >(
             uploader: &'a MultiPartsV2Uploader<H>,
             mut request: AsyncCompletePartsRequestBuilder<'a, E>,
             source: &D,
@@ -832,29 +860,7 @@ fn may_set_extensions_in_err(err: &mut ResponseError) {
     }
 }
 
-impl<H: Digest> MultiPartsV2Uploader<H> {
-    fn storage(&self) -> storage::Client {
-        self.upload_manager.client().storage()
-    }
-
-    fn access_key(&self) -> ApiResult<AccessKey> {
-        self.upload_manager.upload_token().access_key()
-    }
-
-    fn bucket_name(&self) -> ApiResult<BucketName> {
-        self.upload_manager.upload_token().bucket_name()
-    }
-
-    #[cfg(feature = "async")]
-    async fn async_access_key(&self) -> ApiResult<AccessKey> {
-        self.upload_manager.upload_token().async_access_key().await
-    }
-
-    #[cfg(feature = "async")]
-    async fn async_bucket_name(&self) -> ApiResult<BucketName> {
-        self.upload_manager.upload_token().async_bucket_name().await
-    }
-
+impl<H: Digest + Send + 'static> MultiPartsV2Uploader<H> {
     fn before_request_call(&self, request: &mut RequestBuilderParts<'_>) -> ApiResult<()> {
         self.callbacks.before_request(request).map_err(make_callback_error)
     }
@@ -885,58 +891,6 @@ impl<H: Digest> MultiPartsV2Uploader<H> {
             .map_err(make_callback_error)
     }
 
-    fn up_endpoints(&self, params: &ObjectParams) -> ApiResult<Endpoints> {
-        let options = EndpointsGetOptions::builder().service_names(&[ServiceName::Up]).build();
-        let up_endpoints = if let Some(region_provider) = params.region_provider() {
-            RegionsProviderEndpoints::new(region_provider)
-                .get_endpoints(options)?
-                .into_owned()
-        } else {
-            RegionsProviderEndpoints::new(self.get_bucket_region()?)
-                .get_endpoints(options)?
-                .into_owned()
-        };
-        Ok(up_endpoints)
-    }
-
-    #[cfg(feature = "async")]
-    async fn async_up_endpoints(&self, params: &ObjectParams) -> ApiResult<Endpoints> {
-        let options = EndpointsGetOptions::builder().service_names(&[ServiceName::Up]).build();
-        let up_endpoints = if let Some(region_provider) = params.region_provider() {
-            RegionsProviderEndpoints::new(region_provider)
-                .async_get_endpoints(options)
-                .await?
-                .into_owned()
-        } else {
-            RegionsProviderEndpoints::new(self.async_get_bucket_region().await?)
-                .async_get_endpoints(options)
-                .await?
-                .into_owned()
-        };
-        Ok(up_endpoints)
-    }
-
-    fn get_bucket_region(&self) -> ApiResult<BucketRegionsProvider> {
-        Ok(self
-            .upload_manager
-            .queryer()
-            .query(self.access_key()?, self.bucket_name()?))
-    }
-
-    #[cfg(feature = "async")]
-    async fn async_get_bucket_region(&self) -> ApiResult<BucketRegionsProvider> {
-        Ok(self
-            .upload_manager
-            .queryer()
-            .query(self.async_access_key().await?, self.async_bucket_name().await?))
-    }
-
-    fn make_upload_token_signer(&self, object_name: Option<ObjectName>) -> OwnedUploadTokenProviderOrReferenced<'_> {
-        self.upload_manager
-            .upload_token()
-            .make_upload_token_provider(object_name)
-    }
-
     fn call_initialize_parts(
         &self,
         params: &ObjectParams,
@@ -954,7 +908,7 @@ impl<H: Digest> MultiPartsV2Uploader<H> {
             expired_at: UNIX_EPOCH + Duration::from_secs(body.get_expired_at_as_u64()),
         });
 
-        fn _initialize_parts<'a, H: Digest, E: EndpointsProvider + Clone + 'a>(
+        fn _initialize_parts<'a, H: Digest + Send + 'static, E: EndpointsProvider + Clone + 'a>(
             uploader: &'a MultiPartsV2Uploader<H>,
             mut request: SyncInitPartsRequestBuilder<'a, E>,
         ) -> ApiResult<InitPartsResponseBody> {
@@ -985,7 +939,7 @@ impl<H: Digest> MultiPartsV2Uploader<H> {
             expired_at: UNIX_EPOCH + Duration::from_secs(initialized_parts.get_expired_at_as_u64()),
         });
 
-        async fn _initialize_parts<'a, H: Digest, E: EndpointsProvider + Clone + 'a>(
+        async fn _initialize_parts<'a, H: Digest + Send + 'static, E: EndpointsProvider + Clone + 'a>(
             uploader: &'a MultiPartsV2Uploader<H>,
             mut request: AsyncInitPartsRequestBuilder<'a, E>,
         ) -> ApiResult<InitPartsResponseBody> {
@@ -996,7 +950,7 @@ impl<H: Digest> MultiPartsV2Uploader<H> {
         }
     }
 
-    fn try_to_recover<D: DataSource<H>>(
+    fn resume_or_create_records<D: DataSource<H>>(
         &self,
         source: &D,
         params: &ObjectParams,
@@ -1006,61 +960,64 @@ impl<H: Digest> MultiPartsV2Uploader<H> {
         MultiPartsV2ResumableRecorderRecords,
     )> {
         let (info, records) = if let Some(source_key) = source.source_key()? {
-            _try_to_recover(self, &source_key, params).ok().flatten().map_or_else(
-                || {
-                    (
-                        None,
-                        _create_new_records(&self.resumable_recorder, &source_key, up_endpoints),
-                    )
-                },
-                |(info, records)| (Some(info), records),
-            )
+            self.try_to_resume_records(&source_key, params)
+                .ok()
+                .flatten()
+                .map_or_else(
+                    || {
+                        (
+                            None,
+                            _create_new_records(&self.resumable_recorder, &source_key, up_endpoints),
+                        )
+                    },
+                    |(info, records)| (Some(info), records),
+                )
         } else {
             (None, MultiPartsV2ResumableRecorderRecords::new(up_endpoints))
         };
-        return Ok((info, records));
+        Ok((info, records))
+    }
 
-        fn _try_to_recover<H: Digest>(
-            uploader: &MultiPartsV2Uploader<H>,
-            source_key: &SourceKey<H>,
-            params: &ObjectParams,
-        ) -> ApiResult<
-            Option<(
-                MultiPartsV2UploaderInitializedResponseInfo,
-                MultiPartsV2ResumableRecorderRecords,
-            )>,
-        > {
-            let mut medium = uploader.resumable_recorder.open_for_read(source_key)?;
-            let mut lines = BufReader::new(&mut medium).lines();
-            let (info, up_endpoints) = if let Some(line) = lines.next() {
-                let line = line?;
-                let mut header: MultiPartsV2ResumableRecorderDeserializableHeader = serde_json::from_str(&line)?;
-                if !header.is_v2()
-                    || header.expired_at() <= SystemTime::now()
-                    || header.bucket() != uploader.bucket_name()?.as_str()
-                    || header.object() != params.object_name()
-                {
-                    return Ok(None);
-                }
-                let info = MultiPartsV2UploaderInitializedResponseInfo {
-                    upload_id: take(&mut header.upload_id),
-                    expired_at: header.expired_at(),
-                };
-                (info, header.up_endpoints)
-            } else {
+    fn try_to_resume_records(
+        &self,
+        source_key: &SourceKey<H>,
+        params: &ObjectParams,
+    ) -> ApiResult<
+        Option<(
+            MultiPartsV2UploaderInitializedResponseInfo,
+            MultiPartsV2ResumableRecorderRecords,
+        )>,
+    > {
+        let mut medium = self.resumable_recorder.open_for_read(source_key)?;
+        let mut lines = BufReader::new(&mut medium).lines();
+        let (info, up_endpoints) = if let Some(line) = lines.next() {
+            let line = line?;
+            let mut header: MultiPartsV2ResumableRecorderDeserializableHeader = serde_json::from_str(&line)?;
+            if !header.is_v2()
+                || header.expired_at() <= SystemTime::now()
+                || header.bucket() != self.bucket_name()?.as_str()
+                || header.object() != params.object_name()
+            {
                 return Ok(None);
+            }
+            let info = MultiPartsV2UploaderInitializedResponseInfo {
+                upload_id: take(&mut header.upload_id),
+                expired_at: header.expired_at(),
             };
-            let mut records = lines
-                .map(|line| {
-                    let line = line?;
-                    let record: MultiPartsV2ResumableRecorderRecord = serde_json::from_str(&line)?;
-                    Ok(record)
-                })
-                .collect::<ApiResult<MultiPartsV2ResumableRecorderRecords>>()?;
-            records.up_endpoints = up_endpoints;
-            records.set_medium_for_append(uploader.resumable_recorder.open_for_append(source_key)?, true);
-            Ok(Some((info, records)))
-        }
+            (info, header.up_endpoints)
+        } else {
+            return Ok(None);
+        };
+        let mut records = lines
+            .map(|line| {
+                let line = line?;
+                let record: MultiPartsV2ResumableRecorderRecord = serde_json::from_str(&line)?;
+                Ok(record)
+            })
+            .collect::<ApiResult<MultiPartsV2ResumableRecorderRecords>>()?;
+        records.up_endpoints = up_endpoints;
+        records.set_medium_for_append(self.resumable_recorder.open_for_append(source_key)?, true);
+        Ok(Some((info, records)))
     }
 
     fn create_new_records<D: DataSource<H>>(
@@ -1077,7 +1034,7 @@ impl<H: Digest> MultiPartsV2Uploader<H> {
     }
 
     #[cfg(feature = "async")]
-    async fn try_to_async_recover<D: AsyncDataSource<H>>(
+    async fn async_resume_or_create_records<D: AsyncDataSource<H>>(
         &self,
         source: &D,
         params: &ObjectParams,
@@ -1087,7 +1044,12 @@ impl<H: Digest> MultiPartsV2Uploader<H> {
         MultiPartsV2ResumableRecorderRecords,
     )> {
         let result = if let Some(source_key) = source.source_key().await? {
-            if let Some((info, records)) = _try_to_recover(self, &source_key, params).await.ok().flatten() {
+            if let Some((info, records)) = self
+                .try_to_async_resume_records(&source_key, params)
+                .await
+                .ok()
+                .flatten()
+            {
                 (Some(info), records)
             } else {
                 (
@@ -1098,52 +1060,50 @@ impl<H: Digest> MultiPartsV2Uploader<H> {
         } else {
             (None, MultiPartsV2ResumableRecorderRecords::new(up_endpoints))
         };
-        return Ok(result);
+        Ok(result)
+    }
 
-        async fn _try_to_recover<H: Digest>(
-            uploader: &MultiPartsV2Uploader<H>,
-            source_key: &SourceKey<H>,
-            params: &ObjectParams,
-        ) -> ApiResult<
-            Option<(
-                MultiPartsV2UploaderInitializedResponseInfo,
-                MultiPartsV2ResumableRecorderRecords,
-            )>,
-        > {
-            let mut medium = uploader.resumable_recorder.open_for_async_read(source_key).await?;
-            let mut lines = AsyncBufReader::new(&mut medium).lines();
-            let (info, up_endpoints) = if let Some(line) = lines.try_next().await? {
-                let mut header: MultiPartsV2ResumableRecorderDeserializableHeader = serde_json::from_str(&line)?;
-                if !header.is_v2()
-                    || header.expired_at() <= SystemTime::now()
-                    || header.bucket() != uploader.bucket_name()?.as_str()
-                    || header.object() != params.object_name()
-                {
-                    return Ok(None);
-                }
-                let info = MultiPartsV2UploaderInitializedResponseInfo {
-                    upload_id: take(&mut header.upload_id),
-                    expired_at: header.expired_at(),
-                };
-                (info, header.up_endpoints)
-            } else {
+    #[cfg(feature = "async")]
+    async fn try_to_async_resume_records(
+        &self,
+        source_key: &SourceKey<H>,
+        params: &ObjectParams,
+    ) -> ApiResult<
+        Option<(
+            MultiPartsV2UploaderInitializedResponseInfo,
+            MultiPartsV2ResumableRecorderRecords,
+        )>,
+    > {
+        let mut medium = self.resumable_recorder.open_for_async_read(source_key).await?;
+        let mut lines = AsyncBufReader::new(&mut medium).lines();
+        let (info, up_endpoints) = if let Some(line) = lines.try_next().await? {
+            let mut header: MultiPartsV2ResumableRecorderDeserializableHeader = serde_json::from_str(&line)?;
+            if !header.is_v2()
+                || header.expired_at() <= SystemTime::now()
+                || header.bucket() != self.bucket_name()?.as_str()
+                || header.object() != params.object_name()
+            {
                 return Ok(None);
+            }
+            let info = MultiPartsV2UploaderInitializedResponseInfo {
+                upload_id: take(&mut header.upload_id),
+                expired_at: header.expired_at(),
             };
-            let mut records = lines
-                .map(|line| {
-                    let line = line?;
-                    let record: MultiPartsV2ResumableRecorderRecord = serde_json::from_str(&line)?;
-                    Ok::<_, ResponseError>(record)
-                })
-                .try_collect::<MultiPartsV2ResumableRecorderRecords>()
-                .await?;
-            records.up_endpoints = up_endpoints;
-            records.set_medium_for_async_append(
-                uploader.resumable_recorder.open_for_async_append(source_key).await?,
-                true,
-            );
-            Ok(Some((info, records)))
-        }
+            (info, header.up_endpoints)
+        } else {
+            return Ok(None);
+        };
+        let mut records = lines
+            .map(|line| {
+                let line = line?;
+                let record: MultiPartsV2ResumableRecorderRecord = serde_json::from_str(&line)?;
+                Ok::<_, ResponseError>(record)
+            })
+            .try_collect::<MultiPartsV2ResumableRecorderRecords>()
+            .await?;
+        records.up_endpoints = up_endpoints;
+        records.set_medium_for_async_append(self.resumable_recorder.open_for_async_append(source_key).await?, true);
+        Ok(Some((info, records)))
     }
 
     #[cfg(feature = "async")]
@@ -1969,6 +1929,8 @@ mod tests {
         #[cfg(feature = "async")]
         #[async_std::test]
         async fn test_async_multi_parts_v2_upload_with_recovery() -> Result<()> {
+            use async_std::fs::read_dir as async_read_dir;
+
             env_logger::builder().is_test(true).try_init().ok();
 
             #[derive(Debug)]
@@ -2149,7 +2111,7 @@ mod tests {
                 }
             }
 
-            {
+            let mut initialized_parts = {
                 let uploader = Arc::new(MultiPartsV2Uploader::new(
                     get_upload_manager(FakeHttpCaller2::new(3)),
                     FileSystemResumableRecorder::<Sha1>::new(resuming_files_dir.path()),
@@ -2172,13 +2134,114 @@ mod tests {
                 let parts = parts.into_iter().map(|part| part.unwrap()).collect::<Vec<_>>();
                 let body = uploader.async_complete_parts(&initialized_parts, &parts).await?;
                 assert_eq!(body.get("done").unwrap().as_u64().unwrap(), 1u64);
+                Arc::try_unwrap(initialized_parts).unwrap()
+            };
+
+            assert!(async_read_dir(resuming_files_dir.path()).await?.next().await.is_none());
+
+            #[derive(Debug, Default)]
+            struct FakeHttpCaller3 {
+                init_parts_counts: AtomicUsize,
+                upload_part_counts: AtomicUsize,
+                complete_parts_counts: AtomicUsize,
             }
 
-            assert!(async_std::fs::read_dir(resuming_files_dir.path())
-                .await?
-                .next()
-                .await
-                .is_none());
+            impl HttpCaller for FakeHttpCaller3 {
+                fn call(&self, _request: &mut SyncRequest<'_>) -> SyncResponseResult {
+                    unreachable!()
+                }
+
+                #[cfg(feature = "async")]
+                fn async_call<'a>(&'a self, request: &'a mut AsyncRequest<'_>) -> BoxFuture<'a, AsyncResponseResult> {
+                    Box::pin(async move {
+                        let resp_body = if request
+                            .url()
+                            .path()
+                            .starts_with("/buckets/fakebucket/objects/~/uploads/fakeuploadid/")
+                        {
+                            let page_number: usize;
+                            scan_text!(request.url().path().bytes() => "/buckets/fakebucket/objects/~/uploads/fakeuploadid/{}", page_number);
+                            match size_of_async_reader(request.body_mut()).await.unwrap() {
+                                LAST_BLOCK_SIZE | BLOCK_SIZE => {
+                                    self.upload_part_counts.fetch_add(1, Ordering::Relaxed);
+                                }
+                                _ => unimplemented!(),
+                            }
+                            json_to_vec(&json!({
+                                "etag": format!("==={}===", page_number),
+                                "md5": "fake-md5",
+                            }))
+                            .unwrap()
+                        } else if request.url().path() == "/buckets/fakebucket/objects/~/uploads/fakeuploadid" {
+                            assert_eq!(self.upload_part_counts.load(Ordering::Relaxed), 3);
+                            assert_eq!(self.complete_parts_counts.fetch_add(1, Ordering::Relaxed), 0);
+                            let body: CompletePartsRequestBody = {
+                                let mut req_body = Vec::new();
+                                async_io_copy(request.body_mut(), &mut req_body).await.unwrap();
+                                serde_json::from_slice(&req_body).unwrap()
+                            };
+                            body.get_parts().to_part_info_vec().into_iter().fold(
+                                None,
+                                |last_page_number, part_info| {
+                                    if let Some(last_page_number) = last_page_number {
+                                        assert_eq!(part_info.get_part_number_as_u64(), last_page_number + 1);
+                                        assert_eq!(
+                                            part_info.get_etag_as_str(),
+                                            &format!("==={}===", part_info.get_part_number_as_u64()),
+                                        );
+                                    }
+                                    Some(part_info.get_part_number_as_u64())
+                                },
+                            );
+                            json_to_vec(&json!({
+                                "done": 1,
+                            }))
+                            .unwrap()
+                        } else if request.url().path() == "/buckets/fakebucket/objects/~/uploads" {
+                            assert_eq!(self.init_parts_counts.fetch_add(1, Ordering::Relaxed), 0);
+                            assert_eq!(self.upload_part_counts.load(Ordering::Relaxed), 0);
+                            assert_eq!(self.complete_parts_counts.load(Ordering::Relaxed), 0);
+                            json_to_vec(&json!({
+                                "uploadId": "fakeuploadid",
+                                "expireAt": (SystemTime::now() + Duration::from_secs(3600)).duration_since(UNIX_EPOCH).unwrap().as_secs(),
+                            }))
+                            .unwrap()
+                        } else {
+                            unreachable!()
+                        };
+                        Ok(AsyncResponse::builder()
+                            .status_code(StatusCode::OK)
+                            .header("x-reqid", HeaderValue::from_static("FakeReqid"))
+                            .body(AsyncResponseBody::from_bytes(resp_body))
+                            .build())
+                    })
+                }
+            }
+
+            {
+                let uploader = Arc::new(MultiPartsV2Uploader::new(
+                    get_upload_manager(FakeHttpCaller3::default()),
+                    FileSystemResumableRecorder::<Sha1>::new(resuming_files_dir.path()),
+                ));
+                uploader
+                    .async_reinitialize_parts(&mut initialized_parts, Default::default())
+                    .await?;
+                let initialized_parts = Arc::new(initialized_parts);
+                let tasks = (0..BLOCK_COUNT).map(|_| {
+                    let uploader = uploader.to_owned();
+                    let initialized_parts = initialized_parts.to_owned();
+                    spawn_task(async move {
+                        uploader
+                            .async_upload_part(&initialized_parts, &new_data_partitioner_provider(BLOCK_SIZE))
+                            .await
+                    })
+                });
+                let parts = join_all(tasks).await.into_iter().collect::<ApiResult<Vec<_>>>()?;
+                let parts = parts.into_iter().map(|part| part.unwrap()).collect::<Vec<_>>();
+                let body = uploader.async_complete_parts(&initialized_parts, &parts).await?;
+                assert_eq!(body.get("done").unwrap().as_u64().unwrap(), 1u64);
+            }
+
             Ok(())
         }
     }

--- a/upload-manager/src/scheduler/utils.rs
+++ b/upload-manager/src/scheduler/utils.rs
@@ -1,5 +1,57 @@
-use super::super::ReinitializeOptions;
+use super::super::{InitializedParts, ReinitializeOptions};
+use qiniu_apis::http_client::{Region, RegionsProvider, ResponseError, ResponseErrorKind, RetryDecision};
 
 pub(super) fn keep_original_region_options() -> ReinitializeOptions {
     ReinitializeOptions::builder().keep_original_region().build()
+}
+
+pub(super) fn specify_region_options(regions_provider: impl RegionsProvider + 'static) -> ReinitializeOptions {
+    ReinitializeOptions::builder()
+        .regions_provider(regions_provider)
+        .build()
+}
+
+pub(super) fn need_to_retry(err: &ResponseError) -> bool {
+    matches!(
+        err.retry_decision(),
+        Some(RetryDecision::TryNextServer | RetryDecision::RetryRequest | RetryDecision::Throttled)
+    )
+}
+
+pub(super) fn no_region_tried_error() -> ResponseError {
+    ResponseError::new_with_msg(ResponseErrorKind::NoTry, "None region is tried")
+}
+
+pub(super) fn remove_used_region_from_regions<I: InitializedParts>(regions: &mut Vec<Region>, initialized: &I) {
+    if let Some(found_idx) = regions.iter().position(|r| r.up().similar(initialized.up_endpoints())) {
+        regions.remove(found_idx);
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct UploadResumedPartsError<I: InitializedParts> {
+    pub(super) err: ResponseError,
+    pub(super) resumed: bool,
+    pub(super) initialized: Option<I>,
+}
+
+impl<I: InitializedParts> UploadResumedPartsError<I> {
+    pub(super) fn new(err: ResponseError, resumed: bool, initialized: Option<I>) -> Self {
+        Self {
+            err,
+            resumed,
+            initialized,
+        }
+    }
+}
+
+pub(super) struct UploadPartsError<I: InitializedParts> {
+    pub(super) err: ResponseError,
+    pub(super) initialized: Option<I>,
+}
+
+impl<I: InitializedParts> UploadPartsError<I> {
+    pub(super) fn new(err: ResponseError, initialized: Option<I>) -> Self {
+        Self { err, initialized }
+    }
 }

--- a/upload-token/Cargo.toml
+++ b/upload-token/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qiniu-upload-token"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Rong Zhou <zhourong@qiniu.com>", "Shanghai Qiniu Information Technologies Co., Ltd."]
 edition = "2021"
 rust-version = "1.60.0"
@@ -24,8 +24,8 @@ serde = { version = "1.0.130", features = ["derive"] }
 auto_impl = "1.0.0"
 futures = { version = "0.3.16", optional = true }
 
-qiniu-credential = { version = "0.2.0", path = "../credential" }
-qiniu-utils = { version = "0.2.0", path = "../utils" }
+qiniu-credential = { version = "0.2.1", path = "../credential" }
+qiniu-utils = { version = "0.2.1", path = "../utils" }
 
 [dev-dependencies]
 async-std = { version = "1.6.3", features = ["attributes"] }

--- a/upload-token/README.md
+++ b/upload-token/README.md
@@ -24,14 +24,14 @@
 
 ```toml
 [dependencies]
-qiniu-upload-token = "0.2.0"
+qiniu-upload-token = "0.2.1"
 ```
 
 ### 启用异步接口
 
 ```toml
 [dependencies]
-qiniu-upload-token = { version = "0.2.0", features = ["async"] }
+qiniu-upload-token = { version = "0.2.1", features = ["async"] }
 ```
 
 ## 代码示例

--- a/upload-token/src/upload_policy.rs
+++ b/upload-token/src/upload_policy.rs
@@ -863,7 +863,7 @@ mod tests {
     fn test_build_upload_policy_with_callback() -> Result<()> {
         let policy = UploadPolicyBuilder::new_policy_for_bucket("test_bucket", Duration::from_secs(3600))
             .callback(
-                &["https://1.1.1.1", "https://2.2.2.2", "https://3.3.3.3"],
+                ["https://1.1.1.1", "https://2.2.2.2", "https://3.3.3.3"],
                 "www.qiniu.com",
                 "a=b&c=d",
                 "",
@@ -890,7 +890,7 @@ mod tests {
     fn test_build_upload_policy_with_callback_body_with_body_type() -> Result<()> {
         let policy = UploadPolicyBuilder::new_policy_for_bucket("test_bucket", Duration::from_secs(3600))
             .callback(
-                &["https://1.1.1.1", "https://2.2.2.2", "https://3.3.3.3"],
+                ["https://1.1.1.1", "https://2.2.2.2", "https://3.3.3.3"],
                 "www.qiniu.com",
                 "a=b&c=d",
                 APPLICATION_WWW_FORM_URLENCODED.as_ref(),
@@ -990,7 +990,7 @@ mod tests {
     #[test]
     fn test_build_upload_policy_with_mime() -> Result<()> {
         let policy = UploadPolicyBuilder::new_policy_for_bucket("test_bucket", Duration::from_secs(3600))
-            .mime_types(&["image/jpeg", "image/png"])
+            .mime_types(["image/jpeg", "image/png"])
             .build();
         assert_eq!(
             policy.mime_types().map(|ops| ops.collect::<Vec<&str>>()),

--- a/utils/Cargo.toml
+++ b/utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "qiniu-utils"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Rong Zhou <zhourong@qiniu.com>", "Shanghai Qiniu Information Technologies Co., Ltd."]
 edition = "2021"
 rust-version = "1.60.0"


### PR DESCRIPTION
- `qiniu_upload_manager::MultiPartsV1Uploader` 总是使用 4 MB 分片大小，无论 `qiniu_upload_manager::DataPartitionProvider` 返回多大的分片大小。
- `qiniu_upload_manager::SerialMultiPartsUploaderScheduler` 和 `qiniu_upload_manager::ConcurrentMultiPartsUploaderScheduler` 对空间所在区域上传对象失败后，会使用多活区域继续重试，直到其中有一个能成功为止。